### PR TITLE
compiler: support branch target CFI + allocate and release stacks with MAP_STACK on OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ We also test cross compilation for many `GOOS` and `GOARCH` combinations.
   * macOS is tested only on arm64.
 * Compiler
   * Linux is tested on amd64 and arm64.
-  * Windows, FreeBSD, NetBSD, DragonFly BSD, illumos and Solaris are
+  * Windows, FreeBSD, NetBSD, OpenBSD, DragonFly BSD, illumos and Solaris are
     tested only on amd64.
   * macOS is tested only on arm64.
 

--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -2009,38 +2009,45 @@ L0 (SSA Block: blk0):
 	csel w8, w8, w2, hs
 	br_table_sequence x8, table_index=0
 L7 (SSA Block: blk7):
-	b #0x54 (L6)
+	bti jc
+	b #0x6c (L6)
 L8 (SSA Block: blk8):
+	bti jc
 L5 (SSA Block: blk5):
 	orr w0, wzr, #0xc
 	add sp, sp, #0x10
 	ldr x30, [sp], #0x10
 	ret
 L9 (SSA Block: blk9):
+	bti jc
 L4 (SSA Block: blk4):
 	movz w0, #0xd, lsl 0
 	add sp, sp, #0x10
 	ldr x30, [sp], #0x10
 	ret
 L10 (SSA Block: blk10):
+	bti jc
 L3 (SSA Block: blk3):
 	orr w0, wzr, #0xe
 	add sp, sp, #0x10
 	ldr x30, [sp], #0x10
 	ret
 L11 (SSA Block: blk11):
+	bti jc
 L2 (SSA Block: blk2):
 	orr w0, wzr, #0xf
 	add sp, sp, #0x10
 	ldr x30, [sp], #0x10
 	ret
 L12 (SSA Block: blk12):
+	bti jc
 L1 (SSA Block: blk1):
 	orr w0, wzr, #0x10
 	add sp, sp, #0x10
 	ldr x30, [sp], #0x10
 	ret
 L13 (SSA Block: blk13):
+	bti jc
 L6 (SSA Block: blk6):
 	movz w0, #0xb, lsl 0
 	add sp, sp, #0x10
@@ -2392,6 +2399,7 @@ L0 (SSA Block: blk0):
 	csel w9, w10, w9, hs
 	br_table_sequence x9, table_index=0
 L4 (SSA Block: blk4):
+	bti jc
 L1 (SSA Block: blk1):
 	mov x0, xzr
 	add sp, sp, #0x10
@@ -2399,6 +2407,7 @@ L1 (SSA Block: blk1):
 	ldr x30, [sp], #0x10
 	ret
 L3 (SSA Block: blk3):
+	bti jc
 	ldr x9, [sp, #0x18]
 	str x9, [x8, #0x8]
 	ldr x9, [x8, #0x4b8]
@@ -2462,6 +2471,7 @@ L0 (SSA Block: blk0):
 	csel w9, w10, w9, hs
 	br_table_sequence x9, table_index=0
 L4 (SSA Block: blk4):
+	bti jc
 L1 (SSA Block: blk1):
 	movz w0, #0x2a, lsl 0
 	add sp, sp, #0x10
@@ -2469,6 +2479,7 @@ L1 (SSA Block: blk1):
 	ldr x30, [sp], #0x10
 	ret
 L3 (SSA Block: blk3):
+	bti jc
 	ldr x9, [sp, #0x18]
 	str x9, [x8, #0x8]
 	ldr x9, [x8, #0x4a0]
@@ -2521,6 +2532,7 @@ L0 (SSA Block: blk0):
 	csel w9, w10, w9, hs
 	br_table_sequence x9, table_index=0
 L4 (SSA Block: blk4):
+	bti jc
 	ldr x8, [x8, #0x4c8]
 	ldr w9, [x8]
 	ldr w10, [x8, #0x8]
@@ -2538,6 +2550,7 @@ L1 (SSA Block: blk1):
 	ldr x30, [sp], #0x10
 	ret
 L3 (SSA Block: blk3):
+	bti jc
 	ldr x9, [sp, #0x18]
 	str x9, [x8, #0x8]
 	ldr x9, [x8, #0x4a0]
@@ -2592,6 +2605,7 @@ L0 (SSA Block: blk0):
 	csel w9, w10, w9, hs
 	br_table_sequence x9, table_index=0
 L4 (SSA Block: blk4):
+	bti jc
 L1 (SSA Block: blk1):
 	movz w0, #0x17, lsl 0
 	add sp, sp, #0x10
@@ -2599,6 +2613,7 @@ L1 (SSA Block: blk1):
 	ldr x30, [sp], #0x10
 	ret
 L3 (SSA Block: blk3):
+	bti jc
 	ldr x9, [sp, #0x18]
 	str x9, [x8, #0x8]
 	ldr x9, [x8, #0x4a0]

--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -59,6 +59,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	add sp, sp, #0x10
@@ -70,6 +71,7 @@ L0 (SSA Block: blk0):
 			name: "selects", m: testcases.Selects.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	subs xzr, x4, x5
@@ -102,6 +104,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	ldr d1, #8; b 16; data.f64 64.000000
@@ -126,6 +129,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	add w8, w2, w3
@@ -163,6 +167,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	add x8, x2, x2
@@ -196,6 +201,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	mov x1, xzr
@@ -217,6 +223,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	mov x1, x2
@@ -239,6 +246,7 @@ L1 (SSA Block: blk1):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 L1 (SSA Block: blk1):
@@ -258,6 +266,7 @@ L1 (SSA Block: blk1):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 L1 (SSA Block: blk1):
@@ -286,6 +295,7 @@ L1 (SSA Block: blk1):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	mov x8, xzr
@@ -313,6 +323,7 @@ L1 (SSA Block: blk1):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 L1 (SSA Block: blk1):
@@ -336,6 +347,7 @@ L2 (SSA Block: blk2):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 L1 (SSA Block: blk1):
@@ -365,6 +377,7 @@ L3 (SSA Block: blk3):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 L1 (SSA Block: blk1):
@@ -387,6 +400,7 @@ L1 (SSA Block: blk1):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 L1 (SSA Block: blk1):
@@ -412,6 +426,7 @@ L3 (SSA Block: blk3):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	mov x8, xzr
@@ -439,6 +454,7 @@ L2 (SSA Block: blk2):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	mov x8, xzr
@@ -472,6 +488,7 @@ L3 (SSA Block: blk3):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	mov x8, xzr
@@ -507,6 +524,7 @@ L3 (SSA Block: blk3):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	cbz w2, #0x8 L2
@@ -532,6 +550,7 @@ L1 (SSA Block: blk1):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 L1 (SSA Block: blk1):
@@ -559,6 +578,7 @@ L2 (SSA Block: blk2):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 L1 (SSA Block: blk1):
@@ -593,6 +613,7 @@ L3 (SSA Block: blk3):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 L1 (SSA Block: blk1):
@@ -638,6 +659,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub sp, sp, #0x10
 	orr x27, xzr, #0x10
@@ -721,6 +743,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub sp, sp, #0x20
 	orr x27, xzr, #0x20
@@ -877,6 +900,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	orr x27, xzr, #0xc0
 	sub sp, sp, x27
 	stp x30, x27, [sp, #-0x10]!
@@ -970,6 +994,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	sxtw x0, w2
@@ -1016,6 +1041,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	clz w0, w2
@@ -1043,6 +1069,7 @@ L0 (SSA Block: blk0):
 			m:    testcases.FloatComparisons.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	orr x27, xzr, #0x20
 	sub sp, sp, x27
 	stp x30, x27, [sp, #-0x10]!
@@ -1086,6 +1113,7 @@ L0 (SSA Block: blk0):
 			m:    testcases.FloatConversions.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	msr fpsr, xzr
@@ -1308,6 +1336,7 @@ L3:
 			m:    testcases.NonTrappingFloatConversions.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	fcvtzs x8, d0
@@ -1455,6 +1484,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str x19, [sp, #-0x10]!
 	str x20, [sp, #-0x10]!
@@ -1638,6 +1668,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub sp, sp, #0x10
 	orr x27, xzr, #0x10
@@ -1684,6 +1715,7 @@ L2:
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	uxtw x8, w2
@@ -1711,6 +1743,7 @@ L2:
 			name: "memory_stores", m: testcases.MemoryStores.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	mov x8, xzr
@@ -1893,6 +1926,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub sp, sp, #0x20
 	orr x27, xzr, #0x20
@@ -1941,6 +1975,7 @@ L0 (SSA Block: blk0):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	orr w8, wzr, #0x1
@@ -2002,6 +2037,7 @@ L6 (SSA Block: blk6):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	orr w8, wzr, #0x6
@@ -2060,6 +2096,7 @@ L6 (SSA Block: blk6):
 			m:    testcases.VecShuffle.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str q29, [sp, #-0x10]!
 	str q30, [sp, #-0x10]!
@@ -2081,6 +2118,7 @@ L0 (SSA Block: blk0):
 			m:    testcases.AtomicRmwAdd.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	orr x27, xzr, #0x10
 	sub sp, sp, x27
 	stp x30, x27, [sp, #-0x10]!
@@ -2280,6 +2318,7 @@ L2:
 			m:    testcases.IcmpAndZero.Module,
 			afterFinalizeAMD64: `
 L0 (SSA Block: blk0):
+	endbr64
 	pushq %rbp
 	movq %rsp, %rbp
 	testl %edi, %ecx
@@ -2297,6 +2336,7 @@ L2 (SSA Block: blk2):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	ands wzr, w2, w3
@@ -2318,6 +2358,7 @@ L2 (SSA Block: blk2):
 			m:    testcases.FibonacciTailRecursive.Module,
 			afterFinalizeAMD64: `
 L0 (SSA Block: blk0):
+	endbr64
 	pushq %rbp
 	movq %rsp, %rbp
 	sub $16, %rsp
@@ -2350,6 +2391,7 @@ L5 (SSA Block: blk5):
 `,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	subs wzr, w2, #0x0
@@ -2381,6 +2423,7 @@ L5 (SSA Block: blk5):
 			name: "try_table_catch_all_empty", m: testcases.TryTableCatchAllEmpty.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub sp, sp, #0x10
 	orr x27, xzr, #0x10
@@ -2453,6 +2496,7 @@ L3 (SSA Block: blk3):
 			name: "try_table_catch_all_throw", m: testcases.TryTableCatchAllThrow.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub sp, sp, #0x10
 	orr x27, xzr, #0x10
@@ -2509,6 +2553,7 @@ L3 (SSA Block: blk3):
 			name: "try_table_catch_many_param_throw", m: testcases.TryTableCatchManyParamThrow.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub sp, sp, #0x30
 	orr x27, xzr, #0x30
@@ -2587,6 +2632,7 @@ L3 (SSA Block: blk3):
 			name: "try_table_catch_throw", m: testcases.TryTableCatchThrow.Module,
 			afterFinalizeARM64: `
 L0 (SSA Block: blk0):
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub sp, sp, #0x10
 	orr x27, xzr, #0x10

--- a/internal/engine/wazevo/backend/isa/amd64/abi_entry_preamble.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi_entry_preamble.go
@@ -28,6 +28,7 @@ var (
 // CompileEntryPreamble implements backend.Machine.
 func (m *machine) CompileEntryPreamble(sig *ssa.Signature) []byte {
 	root := m.compileEntryPreamble(sig)
+	m.c.Emit4Bytes(endbr64Instruction)
 	m.encodeWithoutSSA(root)
 	buf := m.c.Buf()
 	return buf

--- a/internal/engine/wazevo/backend/isa/amd64/abi_entry_preamble.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi_entry_preamble.go
@@ -28,7 +28,6 @@ var (
 // CompileEntryPreamble implements backend.Machine.
 func (m *machine) CompileEntryPreamble(sig *ssa.Signature) []byte {
 	root := m.compileEntryPreamble(sig)
-	m.c.Emit4Bytes(endbr64Instruction)
 	m.encodeWithoutSSA(root)
 	buf := m.c.Buf()
 	return buf
@@ -42,9 +41,12 @@ func (m *machine) compileEntryPreamble(sig *ssa.Signature) *instruction {
 
 	//// ----------------------------------- prologue ----------------------------------- ////
 
+	// Landing pad for indirect branch tracking (Intel CET).
+	cur := linkInstr(root, m.allocateInstr().asEndbr64())
+
 	// First, we save executionContextPtrReg into a callee-saved register so that it can be used in epilogue as well.
 	// 		mov %executionContextPtrReg, %savedExecutionContextPtr
-	cur := m.move64(executionContextPtrReg, savedExecutionContextPtr, root)
+	cur = m.move64(executionContextPtrReg, savedExecutionContextPtr, cur)
 
 	// Next is to save the original RBP and RSP into the execution context.
 	cur = m.saveOriginalRSPRBP(cur)

--- a/internal/engine/wazevo/backend/isa/amd64/abi_entry_preamble_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi_entry_preamble_test.go
@@ -20,6 +20,7 @@ func TestMachineCompileEntryPreamble(t *testing.T) {
 				Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64},
 			},
 			exp: `
+	endbr64
 	movq %rax, %rdx
 	mov.q %rbp, 16(%rax)
 	mov.q %rsp, 24(%rax)
@@ -38,6 +39,7 @@ func TestMachineCompileEntryPreamble(t *testing.T) {
 				Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI64, ssa.TypeF32, ssa.TypeF64, ssa.TypeV128, ssa.TypeI64},
 			},
 			exp: `
+	endbr64
 	movq %rax, %rdx
 	mov.q %rbp, 16(%rax)
 	mov.q %rsp, 24(%rax)
@@ -63,6 +65,7 @@ func TestMachineCompileEntryPreamble(t *testing.T) {
 				Results: []ssa.Type{ssa.TypeI32, ssa.TypeV128, ssa.TypeI64, ssa.TypeF32, ssa.TypeF64},
 			},
 			exp: `
+	endbr64
 	movq %rax, %rdx
 	mov.q %rbp, 16(%rax)
 	mov.q %rsp, 24(%rax)
@@ -87,6 +90,7 @@ func TestMachineCompileEntryPreamble(t *testing.T) {
 				Results: []ssa.Type{ssa.TypeI32, ssa.TypeV128, ssa.TypeI64, ssa.TypeF32, ssa.TypeF64},
 			},
 			exp: `
+	endbr64
 	movq %rax, %rdx
 	mov.q %rbp, 16(%rax)
 	mov.q %rsp, 24(%rax)
@@ -120,6 +124,7 @@ func TestMachineCompileEntryPreamble(t *testing.T) {
 				},
 			},
 			exp: `
+	endbr64
 	movq %rax, %rdx
 	mov.q %rbp, 16(%rax)
 	mov.q %rsp, 24(%rax)
@@ -173,6 +178,7 @@ func TestMachineCompileEntryPreamble(t *testing.T) {
 				},
 			},
 			exp: `
+	endbr64
 	movq %rax, %rdx
 	mov.q %rbp, 16(%rax)
 	mov.q %rsp, 24(%rax)
@@ -232,6 +238,7 @@ func TestMachineCompileEntryPreamble(t *testing.T) {
 				},
 			},
 			exp: `
+	endbr64
 	movq %rax, %rdx
 	mov.q %rbp, 16(%rax)
 	mov.q %rsp, 24(%rax)

--- a/internal/engine/wazevo/backend/isa/amd64/abi_go_call.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi_go_call.go
@@ -271,6 +271,7 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 	cur = m.revertRBPRSP(cur)
 	linkInstr(cur, m.allocateInstr().asRet())
 
+	m.c.Emit4Bytes(endbr64Instruction)
 	m.encodeWithoutSSA(m.rootInstr)
 	return m.c.Buf()
 }
@@ -330,6 +331,8 @@ func (m *machine) storeReturnAddressAndExit(cur *instruction, execCtx regalloc.V
 
 	nop, l := m.allocateBrTarget()
 	cur = linkInstr(cur, nop)
+	endbr := m.allocateInstr().asEndbr64()
+	cur = linkInstr(cur, endbr)
 	readRip.asLEA(newOperandLabel(l), ripReg)
 	return cur
 }
@@ -376,6 +379,7 @@ func (m *machine) CompileStackGrowCallSequence() []byte {
 	cur = m.revertRBPRSP(cur)
 	linkInstr(cur, m.allocateInstr().asRet())
 
+	m.c.Emit4Bytes(endbr64Instruction)
 	m.encodeWithoutSSA(m.rootInstr)
 	return m.c.Buf()
 }

--- a/internal/engine/wazevo/backend/isa/amd64/abi_go_call.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi_go_call.go
@@ -26,6 +26,9 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 	cur := m.allocateNop()
 	m.rootInstr = cur
 
+	// Landing pad for indirect branch tracking (Intel CET).
+	cur = linkInstr(cur, m.allocateInstr().asEndbr64())
+
 	// Execution context is always the first argument.
 	execCtrPtr := raxVReg
 
@@ -271,7 +274,6 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 	cur = m.revertRBPRSP(cur)
 	linkInstr(cur, m.allocateInstr().asRet())
 
-	m.c.Emit4Bytes(endbr64Instruction)
 	m.encodeWithoutSSA(m.rootInstr)
 	return m.c.Buf()
 }
@@ -331,6 +333,7 @@ func (m *machine) storeReturnAddressAndExit(cur *instruction, execCtx regalloc.V
 
 	nop, l := m.allocateBrTarget()
 	cur = linkInstr(cur, nop)
+	// Landing pad for indirect branch tracking (Intel CET).
 	endbr := m.allocateInstr().asEndbr64()
 	cur = linkInstr(cur, endbr)
 	readRip.asLEA(newOperandLabel(l), ripReg)
@@ -351,6 +354,9 @@ var stackGrowSaveVRegs = []regalloc.VReg{
 func (m *machine) CompileStackGrowCallSequence() []byte {
 	cur := m.allocateNop()
 	m.rootInstr = cur
+
+	// Landing pad for indirect branch tracking (Intel CET).
+	cur = linkInstr(cur, m.allocateInstr().asEndbr64())
 
 	cur = m.setupRBPRSP(cur)
 
@@ -379,7 +385,6 @@ func (m *machine) CompileStackGrowCallSequence() []byte {
 	cur = m.revertRBPRSP(cur)
 	linkInstr(cur, m.allocateInstr().asRet())
 
-	m.c.Emit4Bytes(endbr64Instruction)
 	m.encodeWithoutSSA(m.rootInstr)
 	return m.c.Buf()
 }

--- a/internal/engine/wazevo/backend/isa/amd64/abi_go_call_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi_go_call_test.go
@@ -36,6 +36,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 			},
 			needModuleContextPtr: true,
 			exp: `
+	endbr64
 	pushq %rbp
 	movq %rsp, %rbp
 	sub $40, %rsp
@@ -109,6 +110,7 @@ L3:
 			},
 			needModuleContextPtr: true,
 			exp: `
+	endbr64
 	pushq %rbp
 	movq %rsp, %rbp
 	sub $40, %rsp
@@ -180,6 +182,7 @@ L3:
 				Results: []ssa.Type{ssa.TypeI32},
 			},
 			exp: `
+	endbr64
 	pushq %rbp
 	movq %rsp, %rbp
 	sub $24, %rsp
@@ -259,6 +262,7 @@ L3:
 				},
 			},
 			exp: `
+	endbr64
 	pushq %rbp
 	movq %rsp, %rbp
 	sub $248, %rsp
@@ -406,6 +410,7 @@ func TestMachine_CompileStackGrowCallSequence(t *testing.T) {
 	_ = m.CompileStackGrowCallSequence()
 
 	require.Equal(t, `
+	endbr64
 	pushq %rbp
 	movq %rsp, %rbp
 	mov.q %rdx, 96(%rax)

--- a/internal/engine/wazevo/backend/isa/amd64/abi_go_call_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi_go_call_test.go
@@ -76,6 +76,7 @@ L2:
 	mov.q %r12, 48(%rax)
 	exit_sequence %rax
 L3:
+	endbr64
 	add $8, %rsp
 	movq 8(%rsp), %rbx
 	movss 16(%rsp), %xmm0
@@ -151,6 +152,7 @@ L2:
 	mov.q %r12, 48(%rax)
 	exit_sequence %rax
 L3:
+	endbr64
 	add $8, %rsp
 	movq 96(%rax), %rdx
 	movq 112(%rax), %r12
@@ -217,6 +219,7 @@ L2:
 	mov.q %r12, 48(%rax)
 	exit_sequence %rax
 L3:
+	endbr64
 	add $8, %rsp
 	movq 96(%rax), %rdx
 	movq 112(%rax), %r12
@@ -313,6 +316,7 @@ L2:
 	mov.q %r12, 48(%rax)
 	exit_sequence %rax
 L3:
+	endbr64
 	add $8, %rsp
 	movsd (%rsp), %xmm0
 	movdqu 8(%rsp), %xmm1
@@ -441,6 +445,7 @@ func TestMachine_CompileStackGrowCallSequence(t *testing.T) {
 	mov.q %r12, 48(%rax)
 	exit_sequence %rax
 L1:
+	endbr64
 	movq 96(%rax), %rdx
 	movq 112(%rax), %r12
 	movq 128(%rax), %r13

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -33,6 +33,8 @@ func (i *instruction) String() string {
 	switch i.kind {
 	case nop0:
 		return "nop"
+	case endbr64:
+		return "endbr64"
 	case sourceOffsetInfo:
 		return fmt.Sprintf("source_offset_info %d", i.u1)
 	case ret:
@@ -663,6 +665,9 @@ type instructionKind byte
 const (
 	nop0 instructionKind = iota + 1
 
+	// endbr64 is a landing pad for Intel CET indirect branch tracking.
+	endbr64
+
 	// Integer arithmetic/bit-twiddling: (add sub and or xor mul, etc.) (32 64) (reg addr imm) reg
 	aluRmiR
 
@@ -1216,6 +1221,11 @@ func (i *instruction) asTailCallReturnCallIndirect(ptr operand, abi *backend.Fun
 
 func (i *instruction) asRet() *instruction {
 	i.kind = ret
+	return i
+}
+
+func (i *instruction) asEndbr64() *instruction {
+	i.kind = endbr64
 	return i
 }
 
@@ -2339,6 +2349,7 @@ const (
 
 var defKinds = [instrMax]defKind{
 	nop0:                   defKindNone,
+	endbr64:                defKindNone,
 	ret:                    defKindNone,
 	movRR:                  defKindOp2,
 	movRM:                  defKindNone,
@@ -2425,6 +2436,7 @@ const (
 
 var useKinds = [instrMax]useKind{
 	nop0:                   useKindNone,
+	endbr64:                useKindNone,
 	ret:                    useKindNone,
 	movRR:                  useKindOp1,
 	movRM:                  useKindOp1RegOp2,

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding.go
@@ -13,7 +13,8 @@ func (i *instruction) encode(c backend.Compiler) (needsLabelResolution bool) {
 	switch kind := i.kind; kind {
 	case nop0, sourceOffsetInfo, defineUninitializedReg, fcvtToSintSequence, fcvtToUintSequence, nopUseReg:
 	case endbr64:
-		c.Emit4Bytes(endbr64Instruction)
+		// endbr64 is the landing pad required by Intel CET indirect branch tracking
+		c.Emit4Bytes(0xfa1e_0ff3)
 	case ret:
 		encodeRet(c)
 	case imm:
@@ -1420,11 +1421,6 @@ func encodeLoad64(c backend.Compiler, m *amode, rd regalloc.RealReg) {
 func encodeRet(c backend.Compiler) {
 	c.EmitByte(0xc3)
 }
-
-// endbr64Instruction encodes "ENDBR64", the landing pad required by
-// Intel CET indirect branch tracking. Emit4Bytes writes little endian bytes,
-// so this emits f3 0f 1e fa.
-const endbr64Instruction = 0xfa1e_0ff3
 
 func encodeEncEnc(
 	c backend.Compiler,

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding.go
@@ -12,6 +12,8 @@ import (
 func (i *instruction) encode(c backend.Compiler) (needsLabelResolution bool) {
 	switch kind := i.kind; kind {
 	case nop0, sourceOffsetInfo, defineUninitializedReg, fcvtToSintSequence, fcvtToUintSequence, nopUseReg:
+	case endbr64:
+		c.Emit4Bytes(endbr64Instruction)
 	case ret:
 		encodeRet(c)
 	case imm:
@@ -1418,6 +1420,11 @@ func encodeLoad64(c backend.Compiler, m *amode, rd regalloc.RealReg) {
 func encodeRet(c backend.Compiler) {
 	c.EmitByte(0xc3)
 }
+
+// endbr64Instruction encodes "ENDBR64", the landing pad required by
+// Intel CET indirect branch tracking. Emit4Bytes writes little endian bytes,
+// so this emits f3 0f 1e fa.
+const endbr64Instruction = 0xfa1e_0ff3
 
 func encodeEncEnc(
 	c backend.Compiler,

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -21,6 +21,11 @@ func TestInstruction_format_encode(t *testing.T) {
 		wantFormat string
 	}{
 		{
+			setup:      func(i *instruction) { i.asEndbr64() },
+			wantFormat: "endbr64",
+			want:       "f30f1efa",
+		},
+		{
 			setup:      func(i *instruction) { i.asRet() },
 			wantFormat: "ret",
 			want:       "c3",

--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -2162,7 +2162,6 @@ func (m *machine) encodeWithoutSSA(root *instruction) {
 func (m *machine) Encode(ctx context.Context) (err error) {
 	m.insertEndbr64ForJumpTableTargets()
 	bufPtr := m.c.BufPtr()
-	m.c.Emit4Bytes(endbr64Instruction)
 
 	var fn string
 	var fnIndex int

--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -2160,7 +2160,9 @@ func (m *machine) encodeWithoutSSA(root *instruction) {
 
 // Encode implements backend.Machine Encode.
 func (m *machine) Encode(ctx context.Context) (err error) {
+	m.insertEndbr64ForJumpTableTargets()
 	bufPtr := m.c.BufPtr()
+	m.c.Emit4Bytes(endbr64Instruction)
 
 	var fn string
 	var fnIndex int
@@ -2246,6 +2248,32 @@ func (m *machine) Encode(ctx context.Context) (err error) {
 		}
 	}
 	return
+}
+
+func (m *machine) insertEndbr64ForJumpTableTargets() {
+	for i := 0; i < m.jmpTableTargetsNext; i++ {
+		for _, target := range m.jmpTableTargets[i] {
+			pos := m.labelPositionPool.Get(int(target))
+			if pos == nil || pos.begin == nil {
+				panic("BUG: jump table target without label position")
+			}
+			if next := pos.begin.next; next != nil && next.kind == endbr64 {
+				continue
+			}
+
+			endbr := m.allocateInstr()
+			endbr.asEndbr64()
+			endbr.prev = pos.begin
+			endbr.next = pos.begin.next
+			if endbr.next != nil {
+				endbr.next.prev = endbr
+			}
+			pos.begin.next = endbr
+			if pos.end == pos.begin {
+				pos.end = endbr
+			}
+		}
+	}
 }
 
 // ResolveRelocations implements backend.Machine.

--- a/internal/engine/wazevo/backend/isa/amd64/machine_pro_epi_logue.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine_pro_epi_logue.go
@@ -15,6 +15,9 @@ func (m *machine) setupPrologue() {
 	cur := m.rootInstr
 	prevInitInst := cur.next
 
+	// Landing pad for indirect branch tracking (Intel CET).
+	cur = linkInstr(cur, m.allocateInstr().asEndbr64())
+
 	// At this point, we have the stack layout as follows:
 	//
 	//                   (high address)

--- a/internal/engine/wazevo/backend/isa/amd64/machine_pro_epi_logue_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine_pro_epi_logue_test.go
@@ -19,6 +19,7 @@ func TestMachine_setupPrologue(t *testing.T) {
 		{
 			spillSlotSize: 0,
 			exp: `
+	endbr64
 	pushq %rbp
 	movq %rsp, %rbp
 	ud2
@@ -26,6 +27,7 @@ func TestMachine_setupPrologue(t *testing.T) {
 		},
 		{
 			exp: `
+	endbr64
 	pushq %rbp
 	movq %rsp, %rbp
 	sub $16, %rsp
@@ -43,6 +45,7 @@ func TestMachine_setupPrologue(t *testing.T) {
 		},
 		{
 			exp: `
+	endbr64
 	pushq %rbp
 	movq %rsp, %rbp
 	sub $16, %rsp

--- a/internal/engine/wazevo/backend/isa/amd64/machine_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine_test.go
@@ -36,6 +36,27 @@ func Test_asImm32(t *testing.T) {
 	require.Equal(t, uint32(0), v)
 }
 
+func TestMachine_insertEndbr64ForJumpTableTargets(t *testing.T) {
+	m := NewBackend().(*machine)
+	for _, l := range []label{1, 2} {
+		nop := m.allocateNop()
+		pos := m.labelPositionPool.GetOrAllocate(int(l))
+		pos.begin, pos.end = nop, nop
+	}
+	m.jmpTableTargets = [][]uint32{{1, 2, 1}}
+	m.jmpTableTargetsNext = 1
+
+	m.insertEndbr64ForJumpTableTargets()
+	m.insertEndbr64ForJumpTableTargets()
+
+	for _, l := range []label{1, 2} {
+		pos := m.labelPositionPool.Get(int(l))
+		require.Equal(t, endbr64, pos.begin.next.kind)
+		require.Equal(t, (*instruction)(nil), pos.begin.next.next)
+		require.Equal(t, pos.begin.next, pos.end)
+	}
+}
+
 func TestMachine_getOperand_Reg(t *testing.T) {
 	for _, tc := range []struct {
 		name         string

--- a/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble.go
@@ -17,6 +17,7 @@ import (
 // also SP and FP are correct Go-runtime-based values, and LR is the return address to the Go-side caller.
 func (m *machine) CompileEntryPreamble(signature *ssa.Signature) []byte {
 	root := m.constructEntryPreamble(signature)
+	m.compiler.Emit4Bytes(btiJCInstruction)
 	m.encode(root)
 	return m.compiler.Buf()
 }

--- a/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble.go
@@ -17,7 +17,6 @@ import (
 // also SP and FP are correct Go-runtime-based values, and LR is the return address to the Go-side caller.
 func (m *machine) CompileEntryPreamble(signature *ssa.Signature) []byte {
 	root := m.constructEntryPreamble(signature)
-	m.compiler.Emit4Bytes(btiJCInstruction)
 	m.encode(root)
 	return m.compiler.Buf()
 }
@@ -145,9 +144,12 @@ func (m *machine) constructEntryPreamble(sig *ssa.Signature) (root *instruction)
 
 	//// ----------------------------------- prologue ----------------------------------- ////
 
+	// Landing pad for branch target identification (ARM BTI).
+	cur := linkInstr(root, m.allocateInstr().asBTI())
+
 	// First, we save executionContextPtrReg into a callee-saved register so that it can be used in epilogue as well.
 	// 		mov savedExecutionContextPtr, x0
-	cur := m.move64(savedExecutionContextPtr, executionContextPtrReg, root)
+	cur = m.move64(savedExecutionContextPtr, executionContextPtrReg, cur)
 
 	// Next, save the current FP, SP and LR into the wazevo.executionContext:
 	// 		str fp, [savedExecutionContextPtr, #OriginalFramePointer]

--- a/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble_test.go
@@ -21,6 +21,7 @@ func TestAbiImpl_constructEntryPreamble(t *testing.T) {
 			name: "empty",
 			sig:  &ssa.Signature{},
 			exp: `
+	bti jc
 	mov x20, x0
 	str x29, [x20, #0x10]
 	mov x27, sp
@@ -44,6 +45,7 @@ func TestAbiImpl_constructEntryPreamble(t *testing.T) {
 				},
 			},
 			exp: `
+	bti jc
 	mov x20, x0
 	str x29, [x20, #0x10]
 	mov x27, sp
@@ -72,6 +74,7 @@ func TestAbiImpl_constructEntryPreamble(t *testing.T) {
 				},
 			},
 			exp: `
+	bti jc
 	mov x20, x0
 	str x29, [x20, #0x10]
 	mov x27, sp
@@ -100,6 +103,7 @@ func TestAbiImpl_constructEntryPreamble(t *testing.T) {
 				},
 			},
 			exp: `
+	bti jc
 	mov x20, x0
 	str x29, [x20, #0x10]
 	mov x27, sp
@@ -136,6 +140,7 @@ func TestAbiImpl_constructEntryPreamble(t *testing.T) {
 				Results: []ssa.Type{f32, f64, i32, f32, i64, i32, f64},
 			},
 			exp: `
+	bti jc
 	mov x20, x0
 	str x29, [x20, #0x10]
 	mov x27, sp
@@ -173,6 +178,7 @@ func TestAbiImpl_constructEntryPreamble(t *testing.T) {
 				},
 			},
 			exp: `
+	bti jc
 	mov x20, x0
 	str x29, [x20, #0x10]
 	mov x27, sp
@@ -235,6 +241,7 @@ func TestAbiImpl_constructEntryPreamble(t *testing.T) {
 				},
 			},
 			exp: `
+	bti jc
 	mov x20, x0
 	str x29, [x20, #0x10]
 	mov x27, sp
@@ -307,6 +314,7 @@ func TestAbiImpl_constructEntryPreamble(t *testing.T) {
 				},
 			},
 			exp: `
+	bti jc
 	mov x20, x0
 	str x29, [x20, #0x10]
 	mov x27, sp

--- a/internal/engine/wazevo/backend/isa/arm64/abi_go_call.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_go_call.go
@@ -243,6 +243,7 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 	ret.asRet()
 	linkInstr(cur, ret)
 
+	m.compiler.Emit4Bytes(btiJCInstruction)
 	m.encode(m.rootInstr)
 	return m.compiler.Buf()
 }
@@ -351,6 +352,9 @@ func (m *machine) storeReturnAddressAndExit(cur *instruction) *instruction {
 	trapSeq := m.allocateInstr()
 	trapSeq.asExitSequence(x0VReg)
 	cur = linkInstr(cur, trapSeq)
+	bti := m.allocateInstr()
+	bti.asBTI()
+	cur = linkInstr(cur, bti)
 	return cur
 }
 

--- a/internal/engine/wazevo/backend/isa/arm64/abi_go_call.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_go_call.go
@@ -27,6 +27,9 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 	cur.asNop0()
 	m.rootInstr = cur
 
+	// Landing pad for branch target identification (ARM BTI).
+	cur = linkInstr(cur, m.allocateInstr().asBTI())
+
 	// Execution context is always the first argument.
 	execCtrPtr := x0VReg
 
@@ -243,7 +246,6 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 	ret.asRet()
 	linkInstr(cur, ret)
 
-	m.compiler.Emit4Bytes(btiJCInstruction)
 	m.encode(m.rootInstr)
 	return m.compiler.Buf()
 }
@@ -352,9 +354,7 @@ func (m *machine) storeReturnAddressAndExit(cur *instruction) *instruction {
 	trapSeq := m.allocateInstr()
 	trapSeq.asExitSequence(x0VReg)
 	cur = linkInstr(cur, trapSeq)
-	bti := m.allocateInstr()
-	bti.asBTI()
-	cur = linkInstr(cur, bti)
+	cur = linkInstr(cur, m.allocateInstr().asBTI())
 	return cur
 }
 

--- a/internal/engine/wazevo/backend/isa/arm64/abi_go_call_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_go_call_test.go
@@ -52,6 +52,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 				},
 			},
 			exp: `
+	bti jc
 	movz x27, #0xa0, lsl 0
 	sub sp, sp, x27
 	stp x30, x27, [sp, #-0x10]!
@@ -197,6 +198,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 			},
 			needModuleContextPtr: true,
 			exp: `
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub x27, sp, #0x30
 	ldr x11, [x0, #0x28]
@@ -286,6 +288,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 			},
 			needModuleContextPtr: true,
 			exp: `
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub x27, sp, #0x30
 	ldr x11, [x0, #0x28]
@@ -372,6 +375,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 				Results: []ssa.Type{ssa.TypeI32},
 			},
 			exp: `
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub x27, sp, #0x20
 	ldr x11, [x0, #0x28]
@@ -456,6 +460,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 				Results: []ssa.Type{},
 			},
 			exp: `
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub x27, sp, #0x20
 	ldr x11, [x0, #0x28]

--- a/internal/engine/wazevo/backend/isa/arm64/abi_go_call_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_go_call_test.go
@@ -122,6 +122,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	adr x27, #0x20
 	str x27, [x0, #0x30]
 	exit_sequence x0
+	bti jc
 	ldr x19, [x0, #0x60]
 	ldr x20, [x0, #0x70]
 	ldr x21, [x0, #0x80]
@@ -242,6 +243,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	adr x27, #0x20
 	str x27, [x0, #0x30]
 	exit_sequence x0
+	bti jc
 	ldr x19, [x0, #0x60]
 	ldr x20, [x0, #0x70]
 	ldr x21, [x0, #0x80]
@@ -333,6 +335,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	adr x27, #0x20
 	str x27, [x0, #0x30]
 	exit_sequence x0
+	bti jc
 	ldr x19, [x0, #0x60]
 	ldr x20, [x0, #0x70]
 	ldr x21, [x0, #0x80]
@@ -414,6 +417,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	adr x27, #0x20
 	str x27, [x0, #0x30]
 	exit_sequence x0
+	bti jc
 	ldr x19, [x0, #0x60]
 	ldr x20, [x0, #0x70]
 	ldr x21, [x0, #0x80]
@@ -497,6 +501,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	adr x27, #0x20
 	str x27, [x0, #0x30]
 	exit_sequence x0
+	bti jc
 	ldr x19, [x0, #0x60]
 	ldr x20, [x0, #0x70]
 	ldr x21, [x0, #0x80]

--- a/internal/engine/wazevo/backend/isa/arm64/instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr.go
@@ -78,6 +78,7 @@ var defKinds = [numInstructionKinds]defKind{
 	fpuMov128:            defKindRD,
 	fpuRR:                defKindRD,
 	fpuRRR:               defKindRD,
+	bti:                  defKindNone,
 	nop0:                 defKindNone,
 	call:                 defKindCall,
 	callInd:              defKindCall,
@@ -218,6 +219,7 @@ var useKinds = [numInstructionKinds]useKind{
 	fpuMov128:            useKindRN,
 	fpuRR:                useKindRN,
 	fpuRRR:               useKindRNRM,
+	bti:                  useKindNone,
 	nop0:                 useKindNone,
 	call:                 useKindCall,
 	callInd:              useKindCallInd,
@@ -1034,6 +1036,8 @@ func (i *instruction) String() (str string) {
 	}
 
 	switch i.kind {
+	case bti:
+		str = "bti jc"
 	case nop0:
 		if i.u1 != 0 {
 			l := label(i.u1)
@@ -1578,6 +1582,8 @@ func (i *instruction) asTailCallIndirect(ptr regalloc.VReg, abi *backend.Functio
 const (
 	// nop0 represents a no-op of zero size.
 	nop0 instructionKind = iota + 1
+	// bti represents a BTI JC landing pad.
+	bti
 	// aluRRR represents an ALU operation with two register sources and a register destination.
 	aluRRR
 	// aluRRRR represents an ALU operation with three register sources and a register destination.
@@ -1792,6 +1798,11 @@ func (i *instruction) sourceOffsetInfo() ssa.SourceOffset {
 
 func (i *instruction) asUDF() *instruction {
 	i.kind = udf
+	return i
+}
+
+func (i *instruction) asBTI() *instruction {
+	i.kind = bti
 	return i
 }
 

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -11,8 +11,7 @@ import (
 
 // Encode implements backend.Machine Encode.
 func (m *machine) Encode(ctx context.Context) error {
-	m.resolveRelativeAddresses(ctx, btiInstructionSize)
-	m.compiler.Emit4Bytes(btiJCInstruction)
+	m.resolveRelativeAddresses(ctx)
 	m.encode(m.rootInstr)
 	if l := len(m.compiler.Buf()); l > maxFunctionExecutableSize {
 		return fmt.Errorf("function size exceeds the limit: %d > %d", l, maxFunctionExecutableSize)
@@ -31,7 +30,9 @@ func (i *instruction) encode(m *machine) {
 	switch kind := i.kind; kind {
 	case nop0, emitSourceOffsetInfo, loadConstBlockArg:
 	case bti:
-		c.Emit4Bytes(btiJCInstruction)
+		// bti encodes "BTI JC", a landing pad valid for both indirect jumps and calls.
+		// https://developer.arm.com/documentation/ddi0602/2024-03/Base-Instructions/BTI--Branch-Target-Identification-
+		c.Emit4Bytes(0xd503_24df)
 	case exitSequence:
 		encodeExitSequence(c, i.rn.reg())
 	case ret:
@@ -442,14 +443,6 @@ func encodeMov64(rd, rn uint32, toIsSp, fromIsSp bool) uint32 {
 		return encodeLogicalShiftedRegister(0b101, 0, rn, 0, regNumberInEncoding[xzr], rd)
 	}
 }
-
-const (
-	// btiJCInstruction encodes "BTI JC", a landing pad valid for both
-	// indirect jumps and calls.
-	// https://developer.arm.com/documentation/ddi0602/2024-03/Base-Instructions/BTI--Branch-Target-Identification-
-	btiJCInstruction   = 0xd503_24df
-	btiInstructionSize = 4
-)
 
 // encodeSystemRegisterMove encodes as "System register move" in
 // https://developer.arm.com/documentation/ddi0596/2020-12/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -11,7 +11,8 @@ import (
 
 // Encode implements backend.Machine Encode.
 func (m *machine) Encode(ctx context.Context) error {
-	m.resolveRelativeAddresses(ctx)
+	m.resolveRelativeAddresses(ctx, btiInstructionSize)
+	m.compiler.Emit4Bytes(btiJCInstruction)
 	m.encode(m.rootInstr)
 	if l := len(m.compiler.Buf()); l > maxFunctionExecutableSize {
 		return fmt.Errorf("function size exceeds the limit: %d > %d", l, maxFunctionExecutableSize)
@@ -29,6 +30,8 @@ func (i *instruction) encode(m *machine) {
 	c := m.compiler
 	switch kind := i.kind; kind {
 	case nop0, emitSourceOffsetInfo, loadConstBlockArg:
+	case bti:
+		c.Emit4Bytes(btiJCInstruction)
 	case exitSequence:
 		encodeExitSequence(c, i.rn.reg())
 	case ret:
@@ -439,6 +442,14 @@ func encodeMov64(rd, rn uint32, toIsSp, fromIsSp bool) uint32 {
 		return encodeLogicalShiftedRegister(0b101, 0, rn, 0, regNumberInEncoding[xzr], rd)
 	}
 }
+
+const (
+	// btiJCInstruction encodes "BTI JC", a landing pad valid for both
+	// indirect jumps and calls.
+	// https://developer.arm.com/documentation/ddi0602/2024-03/Base-Instructions/BTI--Branch-Target-Identification-
+	btiJCInstruction   = 0xd503_24df
+	btiInstructionSize = 4
+)
 
 // encodeSystemRegisterMove encodes as "System register move" in
 // https://developer.arm.com/documentation/ddi0596/2020-12/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
@@ -23,6 +23,7 @@ func TestInstruction_encode(t *testing.T) {
 		setup func(*instruction)
 		want  string
 	}{
+		{want: "df2403d5", setup: func(i *instruction) { i.asBTI() }},
 		{want: "3f441bd5", setup: func(i *instruction) { i.asMovToFPSR(xzrVReg) }},
 		{want: "21441bd5", setup: func(i *instruction) { i.asMovToFPSR(x1VReg) }},
 		{want: "21443bd5", setup: func(i *instruction) { i.asMovFromFPSR(x1VReg) }},

--- a/internal/engine/wazevo/backend/isa/arm64/machine.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine.go
@@ -369,7 +369,9 @@ func (m *machine) resolveAddressingMode(arg0offset, ret0offset int64, i *instruc
 }
 
 // resolveRelativeAddresses resolves the relative addresses before encoding.
-func (m *machine) resolveRelativeAddresses(ctx context.Context) {
+func (m *machine) resolveRelativeAddresses(ctx context.Context, initialOffset int64) {
+	m.insertBTIForJumpTableTargets()
+
 	if len(m.unresolvedAddressModes) > 0 {
 		arg0offset, ret0offset := m.arg0OffsetFromSP(), m.ret0OffsetFromSP()
 		for _, i := range m.unresolvedAddressModes {
@@ -395,7 +397,7 @@ func (m *machine) resolveRelativeAddresses(ctx context.Context) {
 		}
 
 		// Next, in order to determine the offsets of relative jumps, we have to calculate the size of each label.
-		var offset int64
+		offset := initialOffset
 		for i, pos := range m.orderedSSABlockLabelPos {
 			pos.binaryOffset = offset
 			var size int64
@@ -462,7 +464,7 @@ func (m *machine) resolveRelativeAddresses(ctx context.Context) {
 		}
 	}
 
-	var currentOffset int64
+	currentOffset := initialOffset
 	for cur := m.rootInstr; cur != nil; cur = cur.next {
 		switch cur.kind {
 		case br:
@@ -499,6 +501,32 @@ func (m *machine) resolveRelativeAddresses(ctx context.Context) {
 			m.compiler.AddSourceOffsetInfo(currentOffset, cur.sourceOffsetInfo())
 		}
 		currentOffset += cur.size()
+	}
+}
+
+func (m *machine) insertBTIForJumpTableTargets() {
+	for i := 0; i < m.jmpTableTargetsNext; i++ {
+		for _, target := range m.jmpTableTargets[i] {
+			pos := m.labelPositionPool.Get(int(target))
+			if pos == nil || pos.begin == nil {
+				panic("BUG: jump table target without label position")
+			}
+			if next := pos.begin.next; next != nil && next.kind == bti {
+				continue
+			}
+
+			bti := m.allocateInstr()
+			bti.asBTI()
+			bti.prev = pos.begin
+			bti.next = pos.begin.next
+			if bti.next != nil {
+				bti.next.prev = bti
+			}
+			pos.begin.next = bti
+			if pos.end == pos.begin {
+				pos.end = bti
+			}
+		}
 	}
 }
 

--- a/internal/engine/wazevo/backend/isa/arm64/machine.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine.go
@@ -369,7 +369,7 @@ func (m *machine) resolveAddressingMode(arg0offset, ret0offset int64, i *instruc
 }
 
 // resolveRelativeAddresses resolves the relative addresses before encoding.
-func (m *machine) resolveRelativeAddresses(ctx context.Context, initialOffset int64) {
+func (m *machine) resolveRelativeAddresses(ctx context.Context) {
 	m.insertBTIForJumpTableTargets()
 
 	if len(m.unresolvedAddressModes) > 0 {
@@ -397,7 +397,7 @@ func (m *machine) resolveRelativeAddresses(ctx context.Context, initialOffset in
 		}
 
 		// Next, in order to determine the offsets of relative jumps, we have to calculate the size of each label.
-		offset := initialOffset
+		var offset int64
 		for i, pos := range m.orderedSSABlockLabelPos {
 			pos.binaryOffset = offset
 			var size int64
@@ -464,7 +464,7 @@ func (m *machine) resolveRelativeAddresses(ctx context.Context, initialOffset in
 		}
 	}
 
-	currentOffset := initialOffset
+	var currentOffset int64
 	for cur := m.rootInstr; cur != nil; cur = cur.next {
 		switch cur.kind {
 		case br:

--- a/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue.go
@@ -472,6 +472,7 @@ func (m *machine) CompileStackGrowCallSequence() []byte {
 	ret.asRet()
 	linkInstr(cur, ret)
 
+	m.compiler.Emit4Bytes(btiJCInstruction)
 	m.encode(m.rootInstr)
 	return m.compiler.Buf()
 }

--- a/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue.go
@@ -18,6 +18,9 @@ func (m *machine) setupPrologue() {
 	cur := m.rootInstr
 	prevInitInst := cur.next
 
+	// Landing pad for branch target identification (ARM BTI).
+	cur = linkInstr(cur, m.allocateInstr().asBTI())
+
 	//
 	//                   (high address)                    (high address)
 	//         SP----> +-----------------+               +------------------+ <----+
@@ -452,6 +455,9 @@ func (m *machine) CompileStackGrowCallSequence() []byte {
 	cur.asNop0()
 	m.rootInstr = cur
 
+	// Landing pad for branch target identification (ARM BTI).
+	cur = linkInstr(cur, m.allocateInstr().asBTI())
+
 	// Save the callee saved and argument registers.
 	cur = m.saveRegistersInExecutionContext(cur, saveRequiredRegs)
 
@@ -472,7 +478,6 @@ func (m *machine) CompileStackGrowCallSequence() []byte {
 	ret.asRet()
 	linkInstr(cur, ret)
 
-	m.compiler.Emit4Bytes(btiJCInstruction)
 	m.encode(m.rootInstr)
 	return m.compiler.Buf()
 }

--- a/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue_test.go
@@ -19,6 +19,7 @@ func TestMachine_setupPrologue(t *testing.T) {
 		{
 			spillSlotSize: 0,
 			exp: `
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str xzr, [sp, #-0x10]!
 	udf
@@ -28,6 +29,7 @@ func TestMachine_setupPrologue(t *testing.T) {
 			spillSlotSize: 0,
 			abi:           backend.FunctionABI{ArgStackSize: 16, RetStackSize: 16},
 			exp: `
+	bti jc
 	orr x27, xzr, #0x20
 	sub sp, sp, x27
 	stp x30, x27, [sp, #-0x10]!
@@ -38,6 +40,7 @@ func TestMachine_setupPrologue(t *testing.T) {
 		{
 			spillSlotSize: 16,
 			exp: `
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	sub sp, sp, #0x10
 	orr x27, xzr, #0x10
@@ -49,6 +52,7 @@ func TestMachine_setupPrologue(t *testing.T) {
 			spillSlotSize: 0,
 			clobberedRegs: []regalloc.VReg{v18VReg, v19VReg, x18VReg, x25VReg},
 			exp: `
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str q18, [sp, #-0x10]!
 	str q19, [sp, #-0x10]!
@@ -63,6 +67,7 @@ func TestMachine_setupPrologue(t *testing.T) {
 			spillSlotSize: 320,
 			clobberedRegs: []regalloc.VReg{v18VReg, v19VReg, x18VReg, x25VReg},
 			exp: `
+	bti jc
 	stp x30, xzr, [sp, #-0x10]!
 	str q18, [sp, #-0x10]!
 	str q19, [sp, #-0x10]!
@@ -79,6 +84,7 @@ func TestMachine_setupPrologue(t *testing.T) {
 			abi:           backend.FunctionABI{ArgStackSize: 320, RetStackSize: 160},
 			clobberedRegs: []regalloc.VReg{v18VReg, v19VReg, x18VReg, x25VReg},
 			exp: `
+	bti jc
 	orr x27, xzr, #0x1e0
 	sub sp, sp, x27
 	stp x30, x27, [sp, #-0x10]!
@@ -282,6 +288,7 @@ func TestMachine_CompileStackGrowCallSequence(t *testing.T) {
 	_ = m.CompileStackGrowCallSequence()
 
 	require.Equal(t, `
+	bti jc
 	str x1, [x0, #0x60]
 	str x2, [x0, #0x70]
 	str x3, [x0, #0x80]

--- a/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue_test.go
@@ -328,6 +328,7 @@ func TestMachine_CompileStackGrowCallSequence(t *testing.T) {
 	adr x27, #0x20
 	str x27, [x0, #0x30]
 	exit_sequence x0
+	bti jc
 	ldr x1, [x0, #0x60]
 	ldr x2, [x0, #0x70]
 	ldr x3, [x0, #0x80]

--- a/internal/engine/wazevo/backend/isa/arm64/machine_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_test.go
@@ -58,6 +58,27 @@ func TestMachine_resolveAddressingMode(t *testing.T) {
 	})
 }
 
+func TestMachine_insertBTIForJumpTableTargets(t *testing.T) {
+	m := NewBackend().(*machine)
+	for _, l := range []label{1, 2} {
+		nop := m.allocateNop()
+		pos := m.labelPositionPool.GetOrAllocate(int(l))
+		pos.begin, pos.end = nop, nop
+	}
+	m.jmpTableTargets = [][]uint32{{1, 2, 1}}
+	m.jmpTableTargetsNext = 1
+
+	m.insertBTIForJumpTableTargets()
+	m.insertBTIForJumpTableTargets()
+
+	for _, l := range []label{1, 2} {
+		pos := m.labelPositionPool.Get(int(l))
+		require.Equal(t, bti, pos.begin.next.kind)
+		require.Equal(t, (*instruction)(nil), pos.begin.next.next)
+		require.Equal(t, pos.begin.next, pos.end)
+	}
+}
+
 func TestMachine_clobberedRegSlotSize(t *testing.T) {
 	m := &machine{clobberedRegs: make([]regalloc.VReg, 10)}
 	require.Equal(t, int64(160), m.clobberedRegSlotSize())

--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -155,7 +155,7 @@ func (c *callEngine) init() {
 	if wazevoapi.StackGuardCheckEnabled {
 		stackSize += wazevoapi.StackGuardCheckGuardPageSize
 	}
-	c.stack = make([]byte, stackSize)
+	c.stack = allocateStack(stackSize)
 	c.stackTop = alignedStackTop(c.stack)
 	if wazevoapi.StackGuardCheckEnabled {
 		c.execCtx.stackBottomPtr = &c.stack[wazevoapi.StackGuardCheckGuardPageSize]
@@ -163,6 +163,14 @@ func (c *callEngine) init() {
 		c.execCtx.stackBottomPtr = &c.stack[0]
 	}
 	c.execCtxPtr = uintptr(unsafe.Pointer(&c.execCtx))
+	runtime.SetFinalizer(c, (*callEngine).finalize)
+}
+
+func (c *callEngine) finalize() {
+	if c.stack != nil {
+		releaseStack(c.stack)
+		c.stack = nil
+	}
 }
 
 // alignedStackTop returns 16-bytes aligned stack top of given stack.
@@ -352,6 +360,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			adjustClonedStack(oldsp, oldTop, newsp, newfp, c.stackTop)
 			// Old stack must be alive until the new stack is adjusted.
 			runtime.KeepAlive(oldStack)
+			releaseStack(oldStack)
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
 			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr, newsp, newfp)
 		case wazevoapi.ExitCodeGrowMemory:
@@ -722,7 +731,7 @@ func (c *callEngine) growStack() (newSP, newFP uintptr, err error) {
 }
 
 func (c *callEngine) cloneStack(l uintptr) (newSP, newFP, newTop uintptr, newStack []byte) {
-	newStack = make([]byte, l)
+	newStack = allocateStack(int(l))
 
 	relSp := c.stackTop - uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall))
 	relFp := c.stackTop - c.execCtx.framePointerBeforeGoCall

--- a/internal/engine/wazevo/stack.go
+++ b/internal/engine/wazevo/stack.go
@@ -1,0 +1,9 @@
+//go:build !openbsd
+
+package wazevo
+
+func allocateStack(size int) []byte {
+	return make([]byte, size)
+}
+
+func releaseStack([]byte) {}

--- a/internal/engine/wazevo/stack_openbsd.go
+++ b/internal/engine/wazevo/stack_openbsd.go
@@ -1,0 +1,23 @@
+package wazevo
+
+import "golang.org/x/sys/unix"
+
+func allocateStack(size int) []byte {
+	stack, err := unix.Mmap(
+		-1,
+		0,
+		size,
+		unix.PROT_READ|unix.PROT_WRITE,
+		unix.MAP_ANON|unix.MAP_PRIVATE|unix.MAP_STACK,
+	)
+	if err != nil {
+		panic(err)
+	}
+	return stack
+}
+
+func releaseStack(stack []byte) {
+	if err := unix.Munmap(stack); err != nil {
+		panic(err)
+	}
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -23,7 +23,7 @@ func CompilerSupports(features api.CoreFeatures) bool {
 
 func compilerPlatformSupports(features api.CoreFeatures) bool {
 	switch runtime.GOOS {
-	case "linux", "darwin", "freebsd", "netbsd", "windows":
+	case "linux", "darwin", "freebsd", "openbsd", "netbsd", "windows":
 		if runtime.GOARCH == "arm64" {
 			if features.IsEnabled(experimental.CoreFeaturesThreads) {
 				return CpuFeatures.Has(CpuFeatureArm64Atomic)


### PR DESCRIPTION
OpenBSD requires execution stacks to come from mappings marked with MAP_STACK, while wazevo switches to a private execution stack before running generated code. Allocate OpenBSD call stacks with mmap(MAP_STACK), release them on finalization and after stack growth, and keep heap backed stacks for other systems.

OpenBSD also enforces branch target CFI when hardware support is present: CET IBT on amd64 and BTI on arm64. Emit ENDBR64 and BTI JC landing pads for generated function entries, entry preambles, Go call trampolines, stack grow trampolines, Go reentry points, and br_table targets; adjust relative address handling where the leading landing pad changes offsets.

Keep README platform wording conservative, since OpenBSD arm64 is locally verified but not covered by CI.