### PR TITLE
fix: allow fd_renumber onto stdio file descriptors

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2520,6 +2520,40 @@ func Test_fdRenumber(t *testing.T) {
 <== errno=ESUCCESS
 `,
 		},
+		// Stdio fds are flagged as preopens but, unlike directory preopens,
+		// they are valid renumber targets: libc emulates freopen/dup2 onto
+		// stdio as open + fd_renumber(fd, stdioFd), e.g. when a program
+		// redirects its own stdin from a file. wasmtime permits this.
+		{
+			name:          "file to stdin",
+			from:          fileFD,
+			to:            sys.FdStdin,
+			expectedErrno: wasip1.ErrnoSuccess,
+			expectedLog: `
+==> wasi_snapshot_preview1.fd_renumber(fd=4,to=0)
+<== errno=ESUCCESS
+`,
+		},
+		{
+			name:          "file to stdout",
+			from:          fileFD,
+			to:            sys.FdStdout,
+			expectedErrno: wasip1.ErrnoSuccess,
+			expectedLog: `
+==> wasi_snapshot_preview1.fd_renumber(fd=4,to=1)
+<== errno=ESUCCESS
+`,
+		},
+		{
+			name:          "file to stderr",
+			from:          fileFD,
+			to:            sys.FdStderr,
+			expectedErrno: wasip1.ErrnoSuccess,
+			expectedLog: `
+==> wasi_snapshot_preview1.fd_renumber(fd=4,to=2)
+<== errno=ESUCCESS
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -300,7 +300,14 @@ func (c *FSContext) Renumber(from, to int32) sys.Errno {
 	// https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_renumberfd-fd-to-fd---errno
 	// https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi-common/src/snapshots/preview_1.rs#L531-L546
 	if toFile, ok := c.openedFiles.Lookup(to); ok {
-		if toFile.IsPreopen {
+		// Stdio file descriptors (0-2) are registered as preopens, but unlike
+		// directory preopens they are legitimate dup2/freopen targets: libc
+		// emulates `freopen(path, mode, stdin)` as open + fd_renumber(fd, 0).
+		// wasmtime permits this; refusing it breaks guests that redirect
+		// stdio (e.g. PostgreSQL initdb feeding its bootstrap script through
+		// stdin). Only directory preopens remain protected, as replacing
+		// those would corrupt libc's preopen path-resolution table.
+		if toFile.IsPreopen && to > FdStderr {
 			return sys.ENOTSUP
 		}
 		_ = toFile.File.Close()

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -248,6 +248,34 @@ func TestFSContext_Renumber(t *testing.T) {
 		// Both are preopen.
 		require.Equal(t, sys.ENOTSUP, fsc.Renumber(3, 3))
 	})
+
+	t.Run("stdio fds are valid renumber targets", func(t *testing.T) {
+		// libc emulates `freopen(path, mode, stdin)` and `dup2(fd, STDIN_FILENO)`
+		// as open + fd_renumber(fd, 0). Unlike directory preopens, stdio file
+		// descriptors must accept renumbering, like wasmtime does.
+		for _, stdioFd := range []int32{FdStdin, FdStdout, FdStderr} {
+			fromFd, errno := fsc.OpenFile(dirFS, dirName, sys.O_RDONLY, 0)
+			require.EqualErrno(t, 0, errno)
+
+			fromFile, ok := fsc.LookupFile(fromFd)
+			require.True(t, ok)
+
+			// Sanity check the target is a stdio entry flagged as preopen.
+			toFile, ok := fsc.LookupFile(stdioFd)
+			require.True(t, ok)
+			require.True(t, toFile.IsPreopen)
+
+			require.EqualErrno(t, 0, fsc.Renumber(fromFd, stdioFd))
+
+			renumbered, ok := fsc.LookupFile(stdioFd)
+			require.True(t, ok)
+			require.Equal(t, fromFile, renumbered)
+
+			// Previous file descriptor shouldn't be used.
+			_, ok = fsc.LookupFile(fromFd)
+			require.False(t, ok)
+		}
+	})
 }
 
 // This is similar to https://github.com/WebAssembly/wasi-testsuite/blob/ac32f57400cdcdd0425d3085c24fc7fc40011d1c/tests/rust/src/bin/fd_readdir.rs#L120


### PR DESCRIPTION
### Problem

`FSContext.Renumber` returns `ENOTSUP` whenever the **target** fd is flagged as a preopen. Stdio fds 0-2 are registered with `IsPreopen: true`, so any guest that redirects its own stdio fails:

wasi-libc lowers `freopen(path, mode, stdin)` / `dup2(fd, STDIN_FILENO)` to `path_open` + `fd_renumber(fd, 0)`. Under wazero the renumber fails, the guest's stdin silently remains the original stream, and subsequent reads misbehave.

**Real-world reproduction:** PGlite (PostgreSQL 17.x compiled to WASI p1) runs `initdb`, which feeds its bootstrap script to itself by `freopen`ing stdin from `/tmp/initdb.boot.txt`. Under wazero it aborts with flex's `input in flex scanner failed`; the same module works under wasmtime, which permits renumbering onto stdio ([preview_1.rs fd_renumber](https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi-common/src/snapshots/preview_1.rs)).

### Change

Allow `fd_renumber` when the target is a stdio fd (0-2), matching wasmtime and POSIX `dup2` semantics. Directory preopens remain protected — replacing those would corrupt libc's preopen path-resolution table, which is the case the original guard exists for.

```go
if toFile.IsPreopen && to > FdStderr {
    return sys.ENOTSUP
}
```

### Testing

- New subtest in `TestFSContext_Renumber` covering renumber onto fds 0/1/2 (entry replaced, source fd invalidated), with the existing directory-preopen `ENOTSUP` cases unchanged.
- New `Test_fdRenumber` table cases (`file to stdin/stdout/stderr` → `ESUCCESS`).
- Full `go test ./...` passes.
- Verified end-to-end: PGlite's `pgl_initdb` completes under wazero with this change and the resulting Postgres answers queries over the wire protocol.

Automated by MisterMal