### PR TITLE
fix: capacity sizing when module maximum exceeds memory limit

### DIFF
--- a/internal/wasm/binary/decoder.go
+++ b/internal/wasm/binary/decoder.go
@@ -214,16 +214,19 @@ type memorySizer func(minPages uint32, maxPages *uint32) (min uint32, capacity u
 func newMemorySizer(memoryLimitPages uint32, memoryCapacityFromMax bool) memorySizer {
 	return func(minPages uint32, maxPages *uint32) (min, capacity, max uint32) {
 		if maxPages != nil {
-			if memoryCapacityFromMax {
-				return minPages, *maxPages, *maxPages
-			}
 			// This is an invalid value: let it propagate, we will fail later.
 			if *maxPages > wasm.MemoryLimitPages {
 				return minPages, minPages, *maxPages
 			}
 			// This is a valid value, but it goes over the run-time limit: return the limit.
 			if *maxPages > memoryLimitPages {
+				if memoryCapacityFromMax {
+					return minPages, memoryLimitPages, memoryLimitPages
+				}
 				return minPages, minPages, memoryLimitPages
+			}
+			if memoryCapacityFromMax {
+				return minPages, *maxPages, *maxPages
 			}
 			return minPages, minPages, *maxPages
 		}

--- a/internal/wasm/binary/memory_test.go
+++ b/internal/wasm/binary/memory_test.go
@@ -105,6 +105,16 @@ func Test_newMemorySizer(t *testing.T) {
 			expectedCapacity: 0,
 			expectedMax:      5,
 		},
+		{
+			name:                  "max > memoryLimitPages memoryCapacityFromMax",
+			memoryCapacityFromMax: true,
+			limit:                 5,
+			min:                   0,
+			max:                   &ten,
+			expectedMin:           0,
+			expectedCapacity:      5,
+			expectedMax:           5,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When `WithMemoryCapacityFromMax` is enabled, `newMemorySizer` uses the module-declared maximum before applying `WithMemoryLimitPages`. As a result, modules whose maximum exceeds the configured memory limit are rejected instead of using that limit as their effective maximum.

This change applies the configured limit first, then uses the resulting effective maximum as the capacity. This fixes the remaining `WithMemoryCapacityFromMax` case reported in #1153. Behavior is unchanged when `WithMemoryCapacityFromMax` is disabled or the module maximum is already within the configured limit.