### PR TITLE
fix: eagerly cache FunctionType.key() during Validate to close a data race

### DIFF
--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -282,6 +282,9 @@ func (m *Module) Validate(enabledFeatures api.CoreFeatures) error {
 	for i := range m.TypeSection {
 		tp := &m.TypeSection[i]
 		tp.CacheNumInUint64()
+		// Cache key() now: it's unsynchronized, so calling it for the first
+		// time from concurrent module instances later would race. See #2520.
+		tp.key()
 	}
 
 	if err := m.validateConcreteRefTypes(); err != nil {

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -563,6 +563,30 @@ func TestStore_getFunctionTypeID(t *testing.T) {
 	})
 }
 
+// TestStore_GetFunctionTypeID_ConcurrentAfterValidate guards against the data
+// race fixed in Module.Validate (see #2520). Unlike TestStore_hammer, it uses
+// a brand-new FunctionType rather than the pre-warmed, package-level v_v - an
+// already-cached key() is just a safe read, so reusing a warm value would
+// mask the race.
+func TestStore_GetFunctionTypeID_ConcurrentAfterValidate(t *testing.T) {
+	m := &Module{TypeSection: []FunctionType{
+		{Params: []ValueType{ValueTypeI32}, Results: []ValueType{ValueTypeI64}},
+	}}
+	require.NoError(t, m.Validate(api.CoreFeaturesV1))
+	s := newStore()
+
+	P := 8               // max count of goroutines
+	N := 1000            // work per goroutine
+	if testing.Short() { // Adjust down if `-test.short`
+		P = 4
+		N = 100
+	}
+	hammer.NewHammer(t, P, N).Run(func(p, n int) {
+		_, err := s.GetFunctionTypeID(&m.TypeSection[0])
+		require.NoError(t, err)
+	}, nil)
+}
+
 func TestGlobalInstance_initialize(t *testing.T) {
 	t.Run("basic type const expr", func(t *testing.T) {
 		for _, vt := range []ValueType{ValueTypeI32, ValueTypeI64, ValueTypeF32, ValueTypeF64} {


### PR DESCRIPTION

Fixes #2520

## Problem

`FunctionType.key()` lazily memoizes its result onto the `FunctionType` value
itself (the `string` field), with an unsynchronized read-check-write:

```go
func (f *FunctionType) key() string {
	if f.string != "" {
		return f.string
	}
	// ... compute ret ...
	f.string = ret
	return ret
}
```

`FunctionType` values in `Module.TypeSection` are shared across every module
instance created from the same `CompiledModule`. `Store.GetFunctionTypeID`
calls `key()` at runtime (not just at compile/instantiate time) — in particular,
`imports/emscripten` calls it on every indirect call dispatched through
`invoke_*`. So two module instances from the same `CompiledModule`, invoked
concurrently (a pattern this repo documents and recommends, see
`examples/concurrent-instantiation`), can race on `f.string` the first time a
given function type is looked up.

`Store.mux` doesn't help here — it protects `Store.typeIDs`, not the
`FunctionType` itself, which outlives any single `Store` and is shared by
value-identity across instances.

## Fix

`Module.Validate` already walks `TypeSection` once, single-threaded, to call
`FunctionType.CacheNumInUint64()` — this happens inside `CompileModule`,
before it returns a `CompiledModule` to the caller, so it's guaranteed to
complete before any instantiation (and therefore any concurrent use) is
possible. This PR adds a `tp.key()` call to that same loop, so `f.string` is
always populated by the time concurrent access can happen. After this,
`key()`'s existing `if f.string != "" { return f.string }` fast path is always
taken at runtime — a safe read of an already-fully-written value, never a
first-write race.

This mirrors the exact mechanism already used for `CacheNumInUint64` for the
same underlying reason (values that need to be safe to read concurrently at
runtime, computed once during the single-threaded compile step). No new
locking, no API change, no behavior change for single-threaded callers — it
just moves already-inevitable work earlier.

The only comment added is a two-line note at the `key()` call site itself,
explaining why an otherwise-unused return value is being forced — without it,
this line looks like dead code and is one refactor away from being deleted,
silently reintroducing the race. `Validate` itself is left undocumented, same
as its sibling `validate*` functions in this file.

## Testing

Added `TestStore_GetFunctionTypeID_ConcurrentAfterValidate`, which:
1. Builds a `Module` with a single, brand-new `FunctionType` (never queried
   before, so `f.string` starts empty).
2. Calls `Validate` on it, matching real `CompileModule` sequencing.
3. Uses `internal/testing/hammer` (the same helper `TestStore_hammer` already
   uses elsewhere in this file) to call `Store.GetFunctionTypeID` on that type
   from 8 goroutines released simultaneously, 1000 times each.

Confirmed:
- **Before this fix**: fails reliably under `-race` (see the issue for the
  exact race report).
- **After this fix**: passes cleanly, 20/20 runs under `-race`.
- `go test -race ./...` (entire repo, all packages including
  `internal/engine/wazevo`, `imports/emscripten`, `internal/integration_test/spectest`
  and its variants, `examples/...`): all pass, no regressions.
- `go test ./...` (entire repo, no `-race`): all pass, no regressions.

I did *not* use a pre-existing shared `FunctionType` (like the package-level
`v_v` that `TestStore_hammer` uses) for the new test, because an
already-cache-warmed `FunctionType` makes the race untestable — a prior,
single-threaded test run can populate `f.string` before the concurrent section
even starts, silently masking the bug. This is also why `TestStore_hammer`
itself doesn't catch this despite superficially doing similar concurrent
instantiation.

## Scope note

I looked for, but did not find, any other lazily-self-memoizing field with the
same shape elsewhere in `internal/wasm` that might have the same issue — happy
to expand the fix if there's a preferred place to look, or if you'd rather see
this addressed differently (e.g. inside `key()` itself via `sync.Once`, though
that adds a per-`FunctionType` allocation/overhead for a fast path that's
supposed to be cheap, which is why I preferred precomputing during the
already-single-threaded `Validate` step instead).
