### PR TITLE
wazevo: test module closed state inline instead of exiting to Go on every back-edge

### DIFF
--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -144,6 +144,11 @@ type (
 		// localsSaveAreaPtr points to the tryHandler's localsSaveArea slice
 		// backing array. Handlers load locals from this slice.
 		localsSaveAreaPtr uintptr
+		// moduleClosedPtr is the address of the calling module instance's Closed word
+		// (wasm.ModuleInstance.Closed), set per call when ensureTermination is enabled.
+		// Compiled loop back-edges load it and call the checkModuleExitCode trampoline
+		// only when it is non-zero, instead of exiting to Go on every back-edge.
+		moduleClosedPtr uintptr
 	}
 )
 
@@ -334,6 +339,11 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 	if ensureTermination {
 		done := m.CloseModuleOnCanceledOrTimeout(ctx)
 		defer done()
+		// The back-edge checks compiled into this module read the Closed word directly:
+		// it is the same fact FailIfClosed asks, and it is written atomically by whoever
+		// closes the module -- the watchdog above, a context cancellation, or an explicit
+		// CloseWithExitCode from another goroutine.
+		c.execCtx.moduleClosedPtr = uintptr(unsafe.Pointer(&m.Closed))
 	}
 
 	if c.stackTop&(16-1) != 0 {

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -259,12 +259,21 @@ signatures:
 blk0: (exec_ctx:i64, module_ctx:i64)
 	Jump blk1
 
-blk1: () <-- (blk0,blk1)
-	v2:i64 = Load exec_ctx, 0x58
-	CallIndirect v2:sig2, exec_ctx
-	Jump blk1
+blk1: () <-- (blk0,blk4)
+	v2:i64 = Load exec_ctx, 0x4e0
+	v3:i64 = Load v2, 0x0
+	Brnz v3, blk3
+	Jump blk4
 
 blk2: ()
+
+blk3: () <-- (blk1)
+	v4:i64 = Load exec_ctx, 0x58
+	CallIndirect v4:sig2, exec_ctx
+	Jump blk4
+
+blk4: () <-- (blk1,blk3)
+	Jump blk1
 `,
 			expAfterPasses: `
 signatures:
@@ -273,9 +282,21 @@ signatures:
 blk0: (exec_ctx:i64, module_ctx:i64)
 	Jump fallthrough
 
-blk1: () <-- (blk0,blk1)
-	v2:i64 = Load exec_ctx, 0x58
-	CallIndirect v2:sig2, exec_ctx
+blk1: () <-- (blk0,blk4)
+	v2:i64 = Load exec_ctx, 0x4e0
+	v3:i64 = Load v2, 0x0
+	Brz v3, blk5
+	Jump fallthrough
+
+blk3: () <-- (blk1)
+	v4:i64 = Load exec_ctx, 0x58
+	CallIndirect v4:sig2, exec_ctx
+	Jump blk4
+
+blk5: () <-- (blk1)
+	Jump fallthrough
+
+blk4: () <-- (blk5,blk3)
 	Jump blk1
 `,
 		},

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -1366,6 +1366,26 @@ func (c *Compiler) lowerCurrentOpcode() {
 		c.switchTo(originalLen, loopHeader)
 
 		if c.ensureTermination {
+			// Test the module's closed state inline, and exit to the host only when it
+			// is set. What the checkModuleExitCode trampoline goes to Go to fetch is a
+			// single word — wasm.ModuleInstance.Closed, whose address the call engine
+			// puts in the execution context — so read it here and keep the trampoline
+			// call on the cold path. Exiting from native code on every back-edge is
+			// what makes ensureTermination cost multiples on loop-heavy modules; the
+			// check itself is a load and a well-predicted branch.
+			closedPtr := builder.AllocateInstruction().
+				AsLoad(c.execCtxPtrValue,
+					wazevoapi.ExecutionContextOffsetModuleClosedPtr.U32(),
+					ssa.TypeI64,
+				).Insert(builder).Return()
+			closed := builder.AllocateInstruction().
+				AsLoad(closedPtr, 0, ssa.TypeI64).Insert(builder).Return()
+
+			checkBlk, afterBlk := builder.AllocateBasicBlock(), builder.AllocateBasicBlock()
+			builder.AllocateInstruction().AsBrnz(closed, ssa.ValuesNil, checkBlk).Insert(builder)
+			builder.AllocateInstruction().AsJump(ssa.ValuesNil, afterBlk).Insert(builder)
+
+			builder.SetCurrentBlock(checkBlk)
 			checkModuleExitCodePtr := builder.AllocateInstruction().
 				AsLoad(c.execCtxPtrValue,
 					wazevoapi.ExecutionContextOffsetCheckModuleExitCodeTrampolineAddress.U32(),
@@ -1376,6 +1396,11 @@ func (c *Compiler) lowerCurrentOpcode() {
 			builder.AllocateInstruction().
 				AsCallIndirect(checkModuleExitCodePtr, &c.checkModuleExitCodeSig, args).
 				Insert(builder)
+			builder.AllocateInstruction().AsJump(ssa.ValuesNil, afterBlk).Insert(builder)
+
+			builder.Seal(checkBlk)
+			builder.SetCurrentBlock(afterBlk)
+			builder.Seal(afterBlk)
 		}
 	case wasm.OpcodeIf:
 		bt := c.readBlockType()

--- a/internal/engine/wazevo/wazevoapi/offsetdata.go
+++ b/internal/engine/wazevo/wazevoapi/offsetdata.go
@@ -74,6 +74,10 @@ const (
 	// where locals are mirrored inside try_table bodies, so that handler blocks
 	// can read throw-time local values after stack-clone restore.
 	ExecutionContextOffsetLocalsSaveAreaPtr Offset = 1240
+	// ExecutionContextOffsetModuleClosedPtr is an offset of `moduleClosedPtr` field in wazevo.executionContext:
+	// the address of the calling module instance's Closed word, which compiled code tests
+	// at loop back-edges when ensureTermination is enabled.
+	ExecutionContextOffsetModuleClosedPtr Offset = 1248
 )
 
 // ModuleContextOffsetData allows the compilers to get the information about offsets to the fields of wazevo.moduleContextOpaque,

--- a/internal/integration_test/bench/ensure_termination_bench_test.go
+++ b/internal/integration_test/bench/ensure_termination_bench_test.go
@@ -1,0 +1,76 @@
+package bench
+
+// What WithCloseOnContextDone costs a loop-heavy module: the same wasm, on a runtime with
+// ensureTermination off and on. The check is compiled into every loop back-edge, so a
+// module whose work IS a loop pays it on every iteration.
+//
+//	go test -bench BenchmarkEnsureTermination -benchtime 2s -count 5 ./internal/integration_test/bench/
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+)
+
+// sumLoopWasm is a module whose only export is a counting loop, assembled here because
+// this package has no wat2wasm. Section sizes are computed rather than hand-counted.
+//
+//	(module
+//	  (func (export "sum") (param i32) (result i64) (local i64)
+//	    (block
+//	      (loop
+//	        (br_if 1 (i32.eqz (local.get 0)))
+//	        (local.set 1 (i64.add (local.get 1) (i64.extend_i32_u (local.get 0))))
+//	        (local.set 0 (i32.sub (local.get 0) (i32.const 1)))
+//	        (br 0)))
+//	    (local.get 1)))
+func sumLoopWasm() []byte {
+	section := func(id byte, content ...byte) []byte {
+		return append([]byte{id, byte(len(content))}, content...)
+	}
+	body := []byte{
+		0x01, 0x01, 0x7e, // one i64 local: the accumulator
+		0x02, 0x40, // block
+		0x03, 0x40, // loop
+		0x20, 0x00, 0x45, 0x0d, 0x01, // br_if 1 (i32.eqz (local.get 0))
+		0x20, 0x01, 0x20, 0x00, 0xad, 0x7c, 0x21, 0x01, // acc += u64(n)
+		0x20, 0x00, 0x41, 0x01, 0x6b, 0x21, 0x00, // n -= 1
+		0x0c, 0x00, // br 0
+		0x0b, 0x0b, // end loop, end block
+		0x20, 0x01, // local.get 1
+		0x0b, // end func
+	}
+	out := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00} // magic + version
+	out = append(out, section(1, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7e)...)         // type: (i32)->i64
+	out = append(out, section(3, 0x01, 0x00)...)                                 // func 0: type 0
+	out = append(out, section(7, 0x01, 0x03, 's', 'u', 'm', 0x00, 0x00)...)      // export "sum"
+	return append(out, section(10, append([]byte{0x01, byte(len(body))}, body...)...)...)
+}
+
+func BenchmarkEnsureTermination(b *testing.B) {
+	const iterations = 1 << 16
+	wasmBytes := sumLoopWasm()
+	for _, tc := range []struct {
+		name              string
+		ensureTermination bool
+	}{{"off", false}, {"on", true}} {
+		b.Run(tc.name, func(b *testing.B) {
+			ctx := context.Background()
+			r := wazero.NewRuntimeWithConfig(ctx,
+				wazero.NewRuntimeConfigCompiler().WithCloseOnContextDone(tc.ensureTermination))
+			defer r.Close(ctx)
+			m, err := r.Instantiate(ctx, wasmBytes)
+			if err != nil {
+				b.Fatal(err)
+			}
+			sum := m.ExportedFunction("sum")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := sum.Call(ctx, iterations); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

With `WithCloseOnContextDone(true)`, the wazevo frontend emits, at every loop back-edge, an indirect call to the  `checkModuleExitCode` trampoline. That trampoline is a full exit from native code into Go, taken unconditionally, on a path that is by definition hot: it is the back-edge of a loop.

What the trampoline goes to Go to fetch is one word `wasm.ModuleInstance.Closed`, which whoever interrupts the call (the `CloseModuleOnCanceledOrTimeout` watchdog, a context cancellation, an explicit `CloseWithExitCode` from another goroutine) has already written atomically. This PR puts that word's address in the execution context and has compiled code test it inline, calling the trampoline only when it is non-zero.

Same check, same every-back-edge granularity, same termination guarantee. The exit to Go now happens once, when the module has actually been closed, instead of on every iteration of every loop.

## Numbers (amd64, Ryzen 7 PRO 7840U, `-benchtime 2s -count 3`, medians)

`internal/integration_test/bench/ensure_termination_bench_test.go` (added here) — a module whose entire body is a counting loop, i.e. the worst case:

| | off | on |
| --- | --- | --- |
| before | 34.2 µs | 1560 µs (**45x**) |
| after | 34.2 µs | 64.8 µs (**1.7x**) |

Real modules, measured in a downstream embedder (armed vs unarmed runtime, same process):

| workload | before | after |
| --- | --- | --- |
| Reed–Solomon decode (AssemblyScript, per-byte GF loops) | 5.5x | 1.45x |
| Reed–Solomon encode | 3.0x | 1.24x |
| libsodium XChaCha20, 640 KiB | 2.6x | 1.12x |
| libsodium Ed25519 verify | 1.5x | 1.24x |

What remains is the branch itself, not the exits, so the residual tracks how tight the loop body is.

## Relationship to #2482

#2482 attacks the same cost by making the exit happen every Nth back-edge behind an experimental option. I measured that approach too (backported onto v1.12.0): at intervals of 256+ it lands at 1.5x on RS decode and 1.06x on XChaCha20 — i.e. the same place this patch lands, because past a small interval the residual is the branch, not the exits. This one gets there with no API surface, no interval to tune, no module-ID/cache plumbing, and without coarsening when an interruption is observed.
