### PR TITLE
wazevo: test module closed state inline at loop back-edges

### DIFF
--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -144,6 +144,11 @@ type (
 		// localsSaveAreaPtr points to the tryHandler's localsSaveArea slice
 		// backing array. Handlers load locals from this slice.
 		localsSaveAreaPtr uintptr
+		// moduleClosedPtr is the address of the calling module instance's Closed word
+		// (wasm.ModuleInstance.Closed), set per call when ensureTermination is enabled.
+		// Compiled loop back-edges load it and call the checkModuleExitCode trampoline
+		// only when it is non-zero, instead of exiting to Go on every back-edge.
+		moduleClosedPtr uintptr
 	}
 )
 
@@ -334,6 +339,11 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 	if ensureTermination {
 		done := m.CloseModuleOnCanceledOrTimeout(ctx)
 		defer done()
+		// The back-edge checks compiled into this module read the Closed word directly:
+		// it is the same fact FailIfClosed asks, and it is written atomically by whoever
+		// closes the module -- the watchdog above, a context cancellation, or an explicit
+		// CloseWithExitCode from another goroutine.
+		c.execCtx.moduleClosedPtr = uintptr(unsafe.Pointer(&m.Closed))
 	}
 
 	if c.stackTop&(16-1) != 0 {

--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -149,6 +149,13 @@ type (
 		// Compiled loop back-edges load it and call the checkModuleExitCode trampoline
 		// only when it is non-zero, instead of exiting to Go on every back-edge.
 		moduleClosedPtr uintptr
+		// interruptCounter is incremented by compiled loop back-edges when ensureTermination
+		// is enabled. Every Nth back-edge (see the loop lowering in the frontend package),
+		// compiled code exits to the checkModuleExitCode trampoline even when Closed is
+		// still zero: the exit into Go code is the loop's only safepoint, since the Go
+		// runtime cannot asynchronously preempt goroutines executing wazevo-generated
+		// machine code.
+		interruptCounter uint64
 	}
 )
 
@@ -343,6 +350,12 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 		// it is the same fact FailIfClosed asks, and it is written atomically by whoever
 		// closes the module -- the watchdog above, a context cancellation, or an explicit
 		// CloseWithExitCode from another goroutine.
+		//
+		// Compiled code reads it with a plain 64-bit load rather than an atomic one. That
+		// is tear-free on the architectures wazevo supports, since the word is naturally
+		// aligned, and only eventual visibility is needed: the counter-driven exit below
+		// bounds how long a stale read can delay the check. Test_moduleClosedPtrLayout
+		// pins the assumption that the value sits at offset 0 of the atomic.Uint64.
 		c.execCtx.moduleClosedPtr = uintptr(unsafe.Pointer(&m.Closed))
 	}
 

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -259,7 +259,7 @@ signatures:
 blk0: (exec_ctx:i64, module_ctx:i64)
 	Jump blk1
 
-blk1: () <-- (blk0,blk4)
+blk1: () <-- (blk0,blk5)
 	v2:i64 = Load exec_ctx, 0x4e0
 	v3:i64 = Load v2, 0x0
 	Brnz v3, blk3
@@ -267,12 +267,22 @@ blk1: () <-- (blk0,blk4)
 
 blk2: ()
 
-blk3: () <-- (blk1)
-	v4:i64 = Load exec_ctx, 0x58
-	CallIndirect v4:sig2, exec_ctx
-	Jump blk4
+blk3: () <-- (blk1,blk4)
+	v9:i64 = Load exec_ctx, 0x58
+	CallIndirect v9:sig2, exec_ctx
+	Jump blk5
 
-blk4: () <-- (blk1,blk3)
+blk4: () <-- (blk1)
+	v4:i64 = Load exec_ctx, 0x4e8
+	v5:i64 = Iconst_64 0x1
+	v6:i64 = Iadd v4, v5
+	Store v6, exec_ctx, 0x4e8
+	v7:i64 = Iconst_64 0xfff
+	v8:i64 = Band v6, v7
+	Brz v8, blk3
+	Jump blk5
+
+blk5: () <-- (blk4,blk3)
 	Jump blk1
 `,
 			expAfterPasses: `
@@ -282,21 +292,37 @@ signatures:
 blk0: (exec_ctx:i64, module_ctx:i64)
 	Jump fallthrough
 
-blk1: () <-- (blk0,blk4)
+blk1: () <-- (blk0,blk5)
 	v2:i64 = Load exec_ctx, 0x4e0
 	v3:i64 = Load v2, 0x0
-	Brz v3, blk5
+	Brnz v3, blk6
 	Jump fallthrough
 
-blk3: () <-- (blk1)
-	v4:i64 = Load exec_ctx, 0x58
-	CallIndirect v4:sig2, exec_ctx
-	Jump blk4
-
-blk5: () <-- (blk1)
+blk4: () <-- (blk1)
+	v4:i64 = Load exec_ctx, 0x4e8
+	v5:i64 = Iconst_64 0x1
+	v6:i64 = Iadd v4, v5
+	Store v6, exec_ctx, 0x4e8
+	v7:i64 = Iconst_64 0xfff
+	v8:i64 = Band v6, v7
+	Brnz v8, blk8
 	Jump fallthrough
 
-blk4: () <-- (blk5,blk3)
+blk7: () <-- (blk4)
+	Jump blk3
+
+blk6: () <-- (blk1)
+	Jump fallthrough
+
+blk3: () <-- (blk6,blk7)
+	v9:i64 = Load exec_ctx, 0x58
+	CallIndirect v9:sig2, exec_ctx
+	Jump blk5
+
+blk8: () <-- (blk4)
+	Jump fallthrough
+
+blk5: () <-- (blk8,blk3)
 	Jump blk1
 `,
 		},

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -259,12 +259,21 @@ signatures:
 blk0: (exec_ctx:i64, module_ctx:i64)
 	Jump blk1
 
-blk1: () <-- (blk0,blk1)
-	v2:i64 = Load exec_ctx, 0x58
-	CallIndirect v2:sig2, exec_ctx
-	Jump blk1
+blk1: () <-- (blk0,blk4)
+	v2:i64 = Load exec_ctx, 0x4e0
+	v3:i64 = Load v2, 0x0
+	Brnz v3, blk3
+	Jump blk4
 
 blk2: ()
+
+blk3: () <-- (blk1)
+	v4:i64 = Load exec_ctx, 0x58
+	CallIndirect v4:sig2, exec_ctx
+	Jump blk4
+
+blk4: () <-- (blk1,blk3)
+	Jump blk1
 `,
 			expAfterPasses: `
 signatures:
@@ -273,9 +282,21 @@ signatures:
 blk0: (exec_ctx:i64, module_ctx:i64)
 	Jump fallthrough
 
-blk1: () <-- (blk0,blk1)
-	v2:i64 = Load exec_ctx, 0x58
-	CallIndirect v2:sig2, exec_ctx
+blk1: () <-- (blk0,blk4)
+	v2:i64 = Load exec_ctx, 0x4e0
+	v3:i64 = Load v2, 0x0
+	Brz v3, blk5
+	Jump fallthrough
+
+blk3: () <-- (blk1)
+	v4:i64 = Load exec_ctx, 0x58
+	CallIndirect v4:sig2, exec_ctx
+	Jump blk4
+
+blk5: () <-- (blk1)
+	Jump fallthrough
+
+blk4: () <-- (blk5,blk3)
 	Jump blk1
 `,
 		},

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -277,7 +277,7 @@ blk4: () <-- (blk1)
 	v5:i64 = Iconst_64 0x1
 	v6:i64 = Iadd v4, v5
 	Store v6, exec_ctx, 0x4e8
-	v7:i64 = Iconst_64 0xfff
+	v7:i64 = Iconst_64 0xff
 	v8:i64 = Band v6, v7
 	Brz v8, blk3
 	Jump blk5
@@ -303,7 +303,7 @@ blk4: () <-- (blk1)
 	v5:i64 = Iconst_64 0x1
 	v6:i64 = Iadd v4, v5
 	Store v6, exec_ctx, 0x4e8
-	v7:i64 = Iconst_64 0xfff
+	v7:i64 = Iconst_64 0xff
 	v8:i64 = Band v6, v7
 	Brnz v8, blk8
 	Jump fallthrough

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -15,13 +15,19 @@ import (
 )
 
 // interruptCheckInterval is the number of loop back-edges between two unconditional exits
-// to Go code when ensureTermination is enabled. See the loop lowering below: the exit
-// exists to be a safepoint, not to check anything, so it can be rare. What bounds it is
-// stop-the-world latency rather than throughput, since a GC waiting on a spinning module
-// waits at most this many back-edges.
+// to Go code when ensureTermination is enabled. See the loop lowering below: the exit is
+// there to be a safepoint, not to check anything, since the Closed test on every back-edge
+// already handles interruption. So the interval trades throughput against how long the rest
+// of the process waits on a spinning module -- a stop-the-world GC in particular, which has
+// to meet every wasm goroutine several times before it can finish, and so waits for rather
+// more than one interval.
+//
+// 256 is the largest value that leaves GC pauses and scheduler latency no worse than exiting
+// on every back-edge, which is what this replaces. Throughput is already flat by here, so
+// raising it buys nothing and costs pauses; re-measure both before changing it.
 //
 // Must be a power of two: the lowering tests interruptCheckInterval-1 as a bit mask.
-const interruptCheckInterval uint64 = 1 << 12
+const interruptCheckInterval uint64 = 1 << 8
 
 type (
 	// loweringState is used to keep the state of lowering.

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -1366,6 +1366,26 @@ func (c *Compiler) lowerCurrentOpcode() {
 		c.switchTo(originalLen, loopHeader)
 
 		if c.ensureTermination {
+			// Test the module's closed state inline, and exit to the host only when it
+			// is set. What the checkModuleExitCode trampoline goes to Go to fetch is a
+			// single word — wasm.ModuleInstance.Closed, whose address the call engine
+			// puts in the execution context — so read it here and keep the trampoline
+			// call on the cold path. Exiting from native code on every back-edge is
+			// what makes ensureTermination cost multiples on loop-heavy modules; the
+			// check itself is a load and a well-predicted branch.
+			closedPtr := builder.AllocateInstruction().
+				AsLoad(c.execCtxPtrValue,
+					wazevoapi.ExecutionContextOffsetModuleClosedPtr.U32(),
+					ssa.TypeI64,
+				).Insert(builder).Return()
+			closed := builder.AllocateInstruction().
+				AsLoad(closedPtr, 0, ssa.TypeI64).Insert(builder).Return()
+
+			checkBlk, afterBlk := builder.AllocateBasicBlock(), builder.AllocateBasicBlock()
+			builder.AllocateInstruction().AsBrnz(closed, ssa.ValuesNil, checkBlk).Insert(builder)
+			builder.AllocateInstruction().AsJump(ssa.ValuesNil, afterBlk).Insert(builder)
+
+			builder.SetCurrentBlock(checkBlk)
 			checkModuleExitCodePtr := builder.AllocateInstruction().
 				AsLoad(c.execCtxPtrValue,
 					wazevoapi.ExecutionContextOffsetCheckModuleExitCodeTrampolineAddress.U32(),
@@ -1376,6 +1396,11 @@ func (c *Compiler) lowerCurrentOpcode() {
 			builder.AllocateInstruction().
 				AsCallIndirect(checkModuleExitCodePtr, &c.checkModuleExitCodeSig, args).
 				Insert(builder)
+			builder.AllocateInstruction().AsJump(ssa.ValuesNil, afterBlk).Insert(builder)
+
+			builder.Seal(checkBlk)
+			builder.SetCurrentBlock(afterBlk)
+			builder.Seal(afterBlk)
 		}
 	case wasm.OpcodeIf:
 		bt := c.readBlockType()

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -14,6 +14,15 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
+// interruptCheckInterval is the number of loop back-edges between two unconditional exits
+// to Go code when ensureTermination is enabled. See the loop lowering below: the exit
+// exists to be a safepoint, not to check anything, so it can be rare. What bounds it is
+// stop-the-world latency rather than throughput, since a GC waiting on a spinning module
+// waits at most this many back-edges.
+//
+// Must be a power of two: the lowering tests interruptCheckInterval-1 as a bit mask.
+const interruptCheckInterval uint64 = 1 << 12
+
 type (
 	// loweringState is used to keep the state of lowering.
 	loweringState struct {
@@ -1368,11 +1377,11 @@ func (c *Compiler) lowerCurrentOpcode() {
 		if c.ensureTermination {
 			// Test the module's closed state inline, and exit to the host only when it
 			// is set. What the checkModuleExitCode trampoline goes to Go to fetch is a
-			// single word — wasm.ModuleInstance.Closed, whose address the call engine
-			// puts in the execution context — so read it here and keep the trampoline
-			// call on the cold path. Exiting from native code on every back-edge is
-			// what makes ensureTermination cost multiples on loop-heavy modules; the
-			// check itself is a load and a well-predicted branch.
+			// single word (wasm.ModuleInstance.Closed, whose address the call engine puts
+			// in the execution context), so read it here and keep the trampoline call on
+			// the cold path. Exiting from native code on every back-edge is what makes
+			// ensureTermination cost multiples on loop-heavy modules; the check itself is
+			// a load and a well-predicted branch.
 			closedPtr := builder.AllocateInstruction().
 				AsLoad(c.execCtxPtrValue,
 					wazevoapi.ExecutionContextOffsetModuleClosedPtr.U32(),
@@ -1381,9 +1390,46 @@ func (c *Compiler) lowerCurrentOpcode() {
 			closed := builder.AllocateInstruction().
 				AsLoad(closedPtr, 0, ssa.TypeI64).Insert(builder).Return()
 
-			checkBlk, afterBlk := builder.AllocateBasicBlock(), builder.AllocateBasicBlock()
+			checkBlk, counterBlk, afterBlk :=
+				builder.AllocateBasicBlock(), builder.AllocateBasicBlock(), builder.AllocateBasicBlock()
+
 			builder.AllocateInstruction().AsBrnz(closed, ssa.ValuesNil, checkBlk).Insert(builder)
+			builder.AllocateInstruction().AsJump(ssa.ValuesNil, counterBlk).Insert(builder)
+
+			// The Closed test above is prompt, but conditional: it exits to Go only when
+			// the module was actually closed. That cannot be the only exit from native
+			// code, because the Go runtime cannot asynchronously preempt a goroutine
+			// executing wazevo-generated machine code. A spinning loop would then never
+			// reach a safepoint, and a stop-the-world GC would livelock on it, freezing
+			// the goroutine that would deliver the close. So also exit to Go
+			// unconditionally every interruptCheckInterval back-edges: when Closed is
+			// clear the trampoline returns immediately, and the round trip through Go
+			// code is itself the safepoint.
+			//
+			// The counter lives in its own block so that each test stays a single fused
+			// compare-and-branch: LowerConditionalBranch only folds a comparison into the
+			// branch when it is the branch's direct operand, so combining the two tests
+			// into one condition would instead materialize both through cset/setcc.
+			builder.SetCurrentBlock(counterBlk)
+			counter := builder.AllocateInstruction().
+				AsLoad(c.execCtxPtrValue,
+					wazevoapi.ExecutionContextOffsetInterruptCounter.U32(),
+					ssa.TypeI64,
+				).Insert(builder).Return()
+			one := builder.AllocateInstruction().AsIconst64(1).Insert(builder).Return()
+			next := builder.AllocateInstruction().AsIadd(counter, one).Insert(builder).Return()
+			builder.AllocateInstruction().
+				AsStore(ssa.OpcodeStore, next, c.execCtxPtrValue,
+					wazevoapi.ExecutionContextOffsetInterruptCounter.U32()).
+				Insert(builder)
+			maskVal := builder.AllocateInstruction().
+				AsIconst64(interruptCheckInterval - 1).Insert(builder).Return()
+			masked := builder.AllocateInstruction().AsBand(next, maskVal).Insert(builder).Return()
+			brz := builder.AllocateInstruction()
+			brz.AsBrz(masked, ssa.ValuesNil, checkBlk)
+			brz.Insert(builder)
 			builder.AllocateInstruction().AsJump(ssa.ValuesNil, afterBlk).Insert(builder)
+			builder.Seal(counterBlk)
 
 			builder.SetCurrentBlock(checkBlk)
 			checkModuleExitCodePtr := builder.AllocateInstruction().

--- a/internal/engine/wazevo/wazevo_test.go
+++ b/internal/engine/wazevo/wazevo_test.go
@@ -81,4 +81,19 @@ func Test_ExecutionContextOffsets(t *testing.T) {
 	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.exceptionParamsPtr)), wazevoapi.ExecutionContextOffsetExceptionParamsPtr)
 	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.caughtExceptionClauseIdx)), wazevoapi.ExecutionContextOffsetCaughtExceptionClauseIdx)
 	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.localsSaveAreaPtr)), wazevoapi.ExecutionContextOffsetLocalsSaveAreaPtr)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.moduleClosedPtr)), wazevoapi.ExecutionContextOffsetModuleClosedPtr)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.interruptCounter)), wazevoapi.ExecutionContextOffsetInterruptCounter)
+}
+
+// Test_moduleClosedPtrLayout pins the assumption callWithStack makes when it stores
+// uintptr(unsafe.Pointer(&m.Closed)) into execCtx.moduleClosedPtr: that the uint64 value of
+// an atomic.Uint64 lives at offset 0 of the struct, so that compiled loop back-edges can
+// read it with a plain aligned 64-bit load.
+func Test_moduleClosedPtrLayout(t *testing.T) {
+	var m wasm.ModuleInstance
+	const sentinel = uint64(0x1122334455667788)
+	m.Closed.Store(sentinel)
+	require.Equal(t, sentinel, *(*uint64)(unsafe.Pointer(&m.Closed)))
+	// Naturally aligned, so the load compiled code performs cannot tear.
+	require.Equal(t, uintptr(0), uintptr(unsafe.Pointer(&m.Closed))%8)
 }

--- a/internal/engine/wazevo/wazevoapi/offsetdata.go
+++ b/internal/engine/wazevo/wazevoapi/offsetdata.go
@@ -78,6 +78,13 @@ const (
 	// the address of the calling module instance's Closed word, which compiled code tests
 	// at loop back-edges when ensureTermination is enabled.
 	ExecutionContextOffsetModuleClosedPtr Offset = 1248
+	// ExecutionContextOffsetInterruptCounter is an offset of `interruptCounter` field in wazevo.executionContext.
+	// Compiled loop back-edges increment it when ensureTermination is enabled, and exit to the
+	// checkModuleExitCode trampoline every N back-edges regardless of the Closed word.
+	// The Go runtime cannot asynchronously preempt goroutines executing wazevo-generated machine
+	// code, so that unconditional exit is the only safepoint inside a wasm loop: without it, a
+	// spinning module would never yield, and stop-the-world GC would livelock waiting on it.
+	ExecutionContextOffsetInterruptCounter Offset = 1256
 )
 
 // ModuleContextOffsetData allows the compilers to get the information about offsets to the fields of wazevo.moduleContextOpaque,

--- a/internal/engine/wazevo/wazevoapi/offsetdata.go
+++ b/internal/engine/wazevo/wazevoapi/offsetdata.go
@@ -74,6 +74,10 @@ const (
 	// where locals are mirrored inside try_table bodies, so that handler blocks
 	// can read throw-time local values after stack-clone restore.
 	ExecutionContextOffsetLocalsSaveAreaPtr Offset = 1240
+	// ExecutionContextOffsetModuleClosedPtr is an offset of `moduleClosedPtr` field in wazevo.executionContext:
+	// the address of the calling module instance's Closed word, which compiled code tests
+	// at loop back-edges when ensureTermination is enabled.
+	ExecutionContextOffsetModuleClosedPtr Offset = 1248
 )
 
 // ModuleContextOffsetData allows the compilers to get the information about offsets to the fields of wazevo.moduleContextOpaque,

--- a/internal/integration_test/bench/ensure_termination_bench_test.go
+++ b/internal/integration_test/bench/ensure_termination_bench_test.go
@@ -1,0 +1,76 @@
+package bench
+
+// What WithCloseOnContextDone costs a loop-heavy module: the same wasm, on a runtime with
+// ensureTermination off and on. The check is compiled into every loop back-edge, so a
+// module whose work IS a loop pays it on every iteration.
+//
+//	go test -bench BenchmarkEnsureTermination -benchtime 2s -count 5 ./internal/integration_test/bench/
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+)
+
+// sumLoopWasm is a module whose only export is a counting loop, assembled here because
+// this package has no wat2wasm. Section sizes are computed rather than hand-counted.
+//
+//	(module
+//	  (func (export "sum") (param i32) (result i64) (local i64)
+//	    (block
+//	      (loop
+//	        (br_if 1 (i32.eqz (local.get 0)))
+//	        (local.set 1 (i64.add (local.get 1) (i64.extend_i32_u (local.get 0))))
+//	        (local.set 0 (i32.sub (local.get 0) (i32.const 1)))
+//	        (br 0)))
+//	    (local.get 1)))
+func sumLoopWasm() []byte {
+	section := func(id byte, content ...byte) []byte {
+		return append([]byte{id, byte(len(content))}, content...)
+	}
+	body := []byte{
+		0x01, 0x01, 0x7e, // one i64 local: the accumulator
+		0x02, 0x40, // block
+		0x03, 0x40, // loop
+		0x20, 0x00, 0x45, 0x0d, 0x01, // br_if 1 (i32.eqz (local.get 0))
+		0x20, 0x01, 0x20, 0x00, 0xad, 0x7c, 0x21, 0x01, // acc += u64(n)
+		0x20, 0x00, 0x41, 0x01, 0x6b, 0x21, 0x00, // n -= 1
+		0x0c, 0x00, // br 0
+		0x0b, 0x0b, // end loop, end block
+		0x20, 0x01, // local.get 1
+		0x0b, // end func
+	}
+	out := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00} // magic + version
+	out = append(out, section(1, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7e)...)         // type: (i32)->i64
+	out = append(out, section(3, 0x01, 0x00)...)                                 // func 0: type 0
+	out = append(out, section(7, 0x01, 0x03, 's', 'u', 'm', 0x00, 0x00)...)      // export "sum"
+	return append(out, section(10, append([]byte{0x01, byte(len(body))}, body...)...)...)
+}
+
+func BenchmarkEnsureTermination(b *testing.B) {
+	const iterations = 1 << 16
+	wasmBytes := sumLoopWasm()
+	for _, tc := range []struct {
+		name              string
+		ensureTermination bool
+	}{{"off", false}, {"on", true}} {
+		b.Run(tc.name, func(b *testing.B) {
+			ctx := context.Background()
+			r := wazero.NewRuntimeWithConfig(ctx,
+				wazero.NewRuntimeConfigCompiler().WithCloseOnContextDone(tc.ensureTermination))
+			defer r.Close(ctx)
+			m, err := r.Instantiate(ctx, wasmBytes)
+			if err != nil {
+				b.Fatal(err)
+			}
+			sum := m.ExportedFunction("sum")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := sum.Call(ctx, iterations); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/integration_test/bench/ensure_termination_bench_test.go
+++ b/internal/integration_test/bench/ensure_termination_bench_test.go
@@ -1,8 +1,11 @@
 package bench
 
 // What WithCloseOnContextDone costs a loop-heavy module: the same wasm, on a runtime with
-// ensureTermination off and on. The check is compiled into every loop back-edge, so a
-// module whose work IS a loop pays it on every iteration.
+// ensureTermination off and on. With it on, each loop back-edge tests the module's Closed
+// word inline and also bumps a counter that forces an exit to Go every Nth back-edge
+// (the exit is a GC safepoint: Go cannot asynchronously preempt goroutines running
+// generated machine code), so a module whose work IS a loop pays the loads and branches
+// on every iteration but rarely exits.
 //
 //	go test -bench BenchmarkEnsureTermination -benchtime 2s -count 5 ./internal/integration_test/bench/
 
@@ -11,10 +14,14 @@ import (
 	"testing"
 
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/internal/testing/binaryencoding"
+	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-// sumLoopWasm is a module whose only export is a counting loop, assembled here because
-// this package has no wat2wasm. Section sizes are computed rather than hand-counted.
+// blockTypeEmpty is the block type of a block or loop producing no results.
+const blockTypeEmpty = 0x40
+
+// sumLoopWasm is a module whose only export is a counting loop:
 //
 //	(module
 //	  (func (export "sum") (param i32) (result i64) (local i64)
@@ -26,26 +33,34 @@ import (
 //	        (br 0)))
 //	    (local.get 1)))
 func sumLoopWasm() []byte {
-	section := func(id byte, content ...byte) []byte {
-		return append([]byte{id, byte(len(content))}, content...)
-	}
-	body := []byte{
-		0x01, 0x01, 0x7e, // one i64 local: the accumulator
-		0x02, 0x40, // block
-		0x03, 0x40, // loop
-		0x20, 0x00, 0x45, 0x0d, 0x01, // br_if 1 (i32.eqz (local.get 0))
-		0x20, 0x01, 0x20, 0x00, 0xad, 0x7c, 0x21, 0x01, // acc += u64(n)
-		0x20, 0x00, 0x41, 0x01, 0x6b, 0x21, 0x00, // n -= 1
-		0x0c, 0x00, // br 0
-		0x0b, 0x0b, // end loop, end block
-		0x20, 0x01, // local.get 1
-		0x0b, // end func
-	}
-	out := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00} // magic + version
-	out = append(out, section(1, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7e)...)         // type: (i32)->i64
-	out = append(out, section(3, 0x01, 0x00)...)                                 // func 0: type 0
-	out = append(out, section(7, 0x01, 0x03, 's', 'u', 'm', 0x00, 0x00)...)      // export "sum"
-	return append(out, section(10, append([]byte{0x01, byte(len(body))}, body...)...)...)
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection: []wasm.FunctionType{{
+			Params:  []wasm.ValueType{wasm.ValueTypeI32},
+			Results: []wasm.ValueType{wasm.ValueTypeI64},
+		}},
+		FunctionSection: []wasm.Index{0},
+		ExportSection:   []wasm.Export{{Name: "sum", Type: wasm.ExternTypeFunc, Index: 0}},
+		CodeSection: []wasm.Code{{
+			LocalTypes: []wasm.ValueType{wasm.ValueTypeI64}, // the accumulator
+			Body: []byte{
+				wasm.OpcodeBlock, blockTypeEmpty,
+				wasm.OpcodeLoop, blockTypeEmpty,
+				// Leave the loop once the counter reaches zero.
+				wasm.OpcodeLocalGet, 0, wasm.OpcodeI32Eqz, wasm.OpcodeBrIf, 1,
+				// acc += u64(n)
+				wasm.OpcodeLocalGet, 1,
+				wasm.OpcodeLocalGet, 0, wasm.OpcodeI64ExtendI32U,
+				wasm.OpcodeI64Add, wasm.OpcodeLocalSet, 1,
+				// n -= 1
+				wasm.OpcodeLocalGet, 0,
+				wasm.OpcodeI32Const, 1, wasm.OpcodeI32Sub, wasm.OpcodeLocalSet, 0,
+				wasm.OpcodeBr, 0,
+				wasm.OpcodeEnd, wasm.OpcodeEnd, // end loop, end block
+				wasm.OpcodeLocalGet, 1,
+				wasm.OpcodeEnd, // end func
+			},
+		}},
+	})
 }
 
 func BenchmarkEnsureTermination(b *testing.B) {


### PR DESCRIPTION
**Fixes #2466.**

## The problem

With `WithCloseOnContextDone`, every loop back-edge calls the `checkModuleExitCode` trampoline, which exits from compiled code into Go unconditionally. The check is cheap; the exit is not. Measured here it costs ~17 ns per back-edge, which is 41x on a tight loop and 1.5-5x on real modules.

## The change

That trampoline exists to read one word: `wasm.ModuleInstance.Closed`. The module engine now stores a pointer to it in the execution context, and compiled back-edges test it inline, calling the trampoline only when it is set. Same word, same kill path, same every-back-edge detection.

## Why the exit stays

Go cannot asynchronously preempt a goroutine running wazevo-generated code -- the preemption signal handler finds no Go function at the interrupted PC and gives up. A loop that exited only when `Closed` was set would hold its P indefinitely, and the goroutine that writes `Closed` might never be scheduled to write it. With a purely conditional check, `internal/integration_test/engine` hangs to the 300 s timeout.

So back-edges also increment a counter and exit unconditionally every `interruptCheckInterval` back-edges. That exit checks nothing when `Closed` is clear the trampoline returns immediately. It exists so the rest of the process can make progress.

## Numbers

amd64 (Ryzen 7 PRO 7840U, Linux), medians of rotated runs.

`BenchmarkEnsureTermination`, added in this PR:

|         | off     | on      | ratio     |
|---------|---------|---------|-----------|
| main    | 28.4 µs | 1166 µs | 41.0x     |
| this PR | 27.9 µs | 56.3 µs | **2.02x** |

Real modules -- Reed-Solomon codec and libsodium, armed vs unarmed in one process:

|                | main  | this PR   |
|----------------|-------|-----------|
| RS decode      | 4.95x | **1.40x** |
| RS encode      | 2.84x | **1.23x** |
| XChaCha20 640K | 2.58x | **1.06x** |
| Ed25519 verify | 1.45x | **1.07x** |

Compared with #2482 -- 16 goroutines saturating 16 Ps, back-edge ~6 µs:

|                 | tight loop | cancel->return |
|-----------------|------------|----------------|
| main            | 41x        | 1.1 ms         |
| #2482, N=4096   | 1.77x      | 39 ms          |
| this PR, N=4096 | 1.76x      | 1.2 ms         |

Same throughput, 30x apart on interruption latency. With a counter alone a spinner must reach its next multiple of N before it notices; here it notices on the next back-edge.

Process health:

| interval                    | GC p50     | sleep(1 ms) lateness p50 |
|-----------------------------|------------|--------------------------|
| main (exit every back-edge) | 81 ms      | 19 ms                    |
| 4096                        | 583 ms     | 64 ms                    |
| **256 (this PR)**           | **57 ms**  | **19 ms**                |

Moving the interval from 4096 to 256 costs nothing measurable on real modules -- all four are within noise of their 4096 figures. Only the synthetic tight loop pays for it, 1.76x -> 2.02x, so the 10x reduction in GC pause is effectively free outside that worst case.

## Why the interval is a constant, not an option

In #2482, N *is* the interruption latency, so users have to choose it and it needs an API. Here the inline test handles interruption on every back-edge, and N only affects how long the rest of the process is held up. That matters -- see the table -- but it isn't a preference: 256 is the largest value that keeps GC pauses and scheduler latency no worse than main, which is the behaviour everyone has today. Throughput is flat from 256 to 4096, so a larger value gives up pauses for nothing.

This PR adds no public or experimental API.

## Cost

Code size grows a compiled TinyGo module by 3.0% over main with `ensureTermination` on (137,669 B unarmed -> 140,654 B on main -> 144,775 B here). Unaffected by the interval, which only changes an immediate operand.

## Testing

- `Test_moduleClosedPtrLayout` pins the layout assumption behind reading `&m.Closed`
- `Test_ExecutionContextOffsets` extended to both new fields
- Frontend lowering goldens updated
- Full `go test ./...` green, including `spectest`, `fuzzcases` and `filecache`; `internal/integration_test/engine` runs in 41.2 s against 40.9 s on main
