### PR TITLE
Fix listener test failure on Go 1.27

### DIFF
--- a/internal/wasmdebug/dwarf.go
+++ b/internal/wasmdebug/dwarf.go
@@ -27,9 +27,6 @@ type line struct {
 
 // NewDWARFLines returns DWARFLines for the given *dwarf.Data.
 func NewDWARFLines(d *dwarf.Data) *DWARFLines {
-	if d == nil {
-		return nil
-	}
 	return &DWARFLines{d: d, linesPerEntry: map[dwarf.Offset][]line{}}
 }
 
@@ -49,7 +46,7 @@ func isTombstoneAddr(addr uint64) bool {
 // Line returns the line information for the given instructionOffset which is an offset in
 // the code section of the original Wasm binary. Returns empty string if the info is not found.
 func (d *DWARFLines) Line(instructionOffset uint64) (ret []string) {
-	if d == nil {
+	if d == nil || d.d == nil {
 		return
 	}
 


### PR DESCRIPTION
Prior to Go 1.27, `debug/Dwarf.New` would return an empty `dwarf.Data` if invalid input was given to `dwarf.New`. In go 1.27 this returns nil instead.  This change caused Module.DWARFLines to become nil, which prevented the recording of source offset information.

Change Module.DWARFLines presence to be entirely controlled by the dwarfEnabled flag: if there is no `dwarf.Data`, the methods in DWARFLines just become a noop.

Fixes #2526