### PR TITLE
wazevo: EH checkpoint optimizations

### DIFF
--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -62,11 +62,31 @@ type (
 	// On match, we restore the stack to the checkpoint state and re-enter at returnAddress.
 	tryHandler struct {
 		// Cloned stack and state from the try_table entry checkpoint,
-		// using the same approach as experimental.Snapshot.
+		// using the same approach as experimental.Snapshot. The full clone
+		// is only taken when the snapshotter is enabled (stack != nil); in
+		// the common case the checkpoint is recorded as spOff/fpOff plus a
+		// small snapshot of the trampoline-owned stack window instead.
 		sp, fp, top    uintptr
 		returnAddress  *byte
 		savedRegisters [64][2]uint64
-		stack          []byte // cloned stack
+		stack          []byte // cloned stack, nil in offset mode
+		// spOff/fpOff record the checkpoint stack/frame pointers as offsets
+		// from the aligned stack top. The frames between a try_table entry
+		// and a throw remain intact in the live stack, so the checkpoint can
+		// be restored by recomputing the pointers against the current stack
+		// top; offsets survive stack growth because growStack copies the
+		// contents top-aligned into the new buffer.
+		spOff, fpOff uintptr
+		// trampWindow snapshots the trampoline-owned region at the entry
+		// stack pointer ([sp, sp+16+frame_size+16), per the Go-call stack
+		// layout: frame_size, sliceSize, the arg/ret slice, the return
+		// address and size_of_arg_ret). A later trampoline exit from the
+		// same frame (e.g. the throw itself) reuses this region, so it must
+		// be restored before resuming at the entry continuation — most
+		// importantly the trampoline return address, which would otherwise
+		// make the resumed code continue after the *throw* site.
+		trampWindow      [32]uint64
+		trampWindowBytes uintptr
 		// catchClauses describes what exceptions this handler catches.
 		catchClauses []wazevoapi.CatchClauseInstance
 		// localsSaveArea is a heap buffer where locals are mirrored inside
@@ -624,15 +644,41 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			info := &me.parent.tryTableInfo[tryTableID]
 			returnAddress := c.execCtx.goCallReturnAddress
 			oldTop, oldSp := c.stackTop, uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall))
-			needLen := uintptr(len(c.stack)) + 16
 			var newSP, newFP, newTop uintptr
 			var newStack []byte
-			if newStack = c.takePooledTryStack(needLen); newStack != nil {
-				newSP, newFP, newTop = c.cloneStackInto(newStack)
+			var spOff, fpOff uintptr
+			var trampWindow [32]uint64
+			var trampWindowBytes uintptr
+			if snapshotEnabled {
+				// Snapshot restores can rewind the live stack to an earlier
+				// state, which would invalidate offset-based checkpoints, so
+				// keep the full clone in that case.
+				needLen := uintptr(len(c.stack)) + 16
+				if newStack = c.takePooledTryStack(needLen); newStack != nil {
+					newSP, newFP, newTop = c.cloneStackInto(newStack)
+				} else {
+					newSP, newFP, newTop, newStack = c.cloneStack(needLen)
+				}
+				adjustClonedStack(oldSp, oldTop, newSP, newFP, newTop)
 			} else {
-				newSP, newFP, newTop, newStack = c.cloneStack(needLen)
+				spOff = oldTop - oldSp
+				fpOff = oldTop - c.execCtx.framePointerBeforeGoCall
+				// Record the entry-time stack top so a stack-buffer move
+				// (growStack) between entry and throw can be detected and
+				// stack-absolute values in the window rebased on restore.
+				newTop = oldTop
+				// Snapshot the trampoline-owned window at the entry stack
+				// pointer (ISA-specific layout, see trampolineWindowBytes).
+				// Derive the view from the typed stack pointer (not a bare
+				// uintptr) to stay checkptr-clean under -race.
+				spPtr := c.execCtx.stackPointerBeforeGoCall
+				trampWindowBytes = trampolineWindowBytes(spPtr, c.execCtx.framePointerBeforeGoCall)
+				if max := uintptr(len(trampWindow)) * 8; trampWindowBytes > max {
+					trampWindowBytes = max
+				}
+				win := unsafe.Slice((*byte)(unsafe.Pointer(spPtr)), trampWindowBytes)
+				copy(unsafe.Slice((*byte)(unsafe.Pointer(&trampWindow[0])), trampWindowBytes), win)
 			}
-			adjustClonedStack(oldSp, oldTop, newSP, newFP, newTop)
 
 			// Allocate a heap buffer for locals so handlers can read throw-time values.
 			// Nested try_tables in the same function (ReuseLocals) share the enclosing handler's save area.
@@ -650,15 +696,19 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			}
 
 			c.tryHandlers = append(c.tryHandlers, tryHandler{
-				sp:             newSP,
-				fp:             newFP,
-				top:            newTop,
-				returnAddress:  returnAddress,
-				savedRegisters: c.execCtx.savedRegisters,
-				stack:          newStack,
-				catchClauses:   info.CatchClauses,
-				moduleInstance: mod,
-				localsSaveArea: saveArea,
+				sp:               newSP,
+				fp:               newFP,
+				top:              newTop,
+				spOff:            spOff,
+				fpOff:            fpOff,
+				trampWindow:      trampWindow,
+				trampWindowBytes: trampWindowBytes,
+				returnAddress:    returnAddress,
+				savedRegisters:   c.execCtx.savedRegisters,
+				stack:            newStack,
+				catchClauses:     info.CatchClauses,
+				moduleInstance:   mod,
+				localsSaveArea:   saveArea,
 			})
 			// Set clauseIdx = -1 (no exception) in execCtx for the compiled code
 			// to read after the trampoline returns.
@@ -721,16 +771,43 @@ func (c *callEngine) doHandleException(exn *wasm.Exception) bool {
 				// Store the caught exception so handler code can read params.
 				c.pendingException = exn
 
-				// Restore the cloned stack (like snapshot.doRestore). The
-				// replaced live stack becomes reusable for future enters.
-				spp := *(**uint64)(unsafe.Pointer(&h.sp))
-				c.tryStackPool = append(c.tryStackPool, c.stack)
-				c.stack = h.stack
-				c.stackTop = h.top
 				ec := &c.execCtx
-				ec.stackBottomPtr = &c.stack[0]
-				ec.stackPointerBeforeGoCall = spp
-				ec.framePointerBeforeGoCall = h.fp
+				if h.stack != nil {
+					// Clone mode (snapshotter enabled): restore the cloned
+					// stack (like snapshot.doRestore). The replaced live
+					// stack becomes reusable for future enters.
+					spp := *(**uint64)(unsafe.Pointer(&h.sp))
+					c.tryStackPool = append(c.tryStackPool, c.stack)
+					c.stack = h.stack
+					c.stackTop = h.top
+					ec.stackBottomPtr = &c.stack[0]
+					ec.stackPointerBeforeGoCall = spp
+					ec.framePointerBeforeGoCall = h.fp
+				} else {
+					// Offset mode: the checkpoint frames are still intact in
+					// the live stack; recompute the pointers against the
+					// current stack top (the stack may have been reallocated
+					// by growStack since the try_table entry, but growth
+					// preserves top-relative positions), and restore the
+					// trampoline-owned window that later trampoline exits
+					// from the same frame may have overwritten. The frames
+					// between the checkpoint and the throw point are
+					// abandoned, as in native unwinding.
+					sp := c.stackTop - h.spOff
+					// Derive the restore window pointer from the stack slice
+					// itself (not a bare uintptr) to stay checkptr-clean
+					// under -race.
+					spPtr := unsafe.Add(unsafe.Pointer(&c.stack[0]), sp-uintptr(unsafe.Pointer(&c.stack[0])))
+					win := unsafe.Slice((*byte)(spPtr), h.trampWindowBytes)
+					copy(win, unsafe.Slice((*byte)(unsafe.Pointer(&h.trampWindow[0])), h.trampWindowBytes))
+					spp := (*uint64)(spPtr)
+					// If growStack moved the stack buffer since the try_table
+					// entry (h.top records the entry-time top), stack-absolute
+					// values in the restored window must be rebased.
+					rebaseTrampolineWindow(spp, h.trampWindowBytes, c.stackTop-h.top)
+					ec.stackPointerBeforeGoCall = spp
+					ec.framePointerBeforeGoCall = c.stackTop - h.fpOff
+				}
 				ec.goCallReturnAddress = h.returnAddress
 				ec.savedRegisters = h.savedRegisters
 

--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -49,6 +49,13 @@ type (
 		// pendingException holds the most recently caught exception, so handler
 		// code can read its params after re-entry.
 		pendingException *wasm.Exception
+		// tryStackPool and trySaveAreaPool are LIFO free lists that reuse the
+		// buffers allocated for try_table entry checkpoints. try handlers are
+		// strictly stack-disciplined, so buffers released on leave/catch can
+		// be reused by the next enter, avoiding a stack-clone allocation per
+		// dynamic try_table enter.
+		tryStackPool    [][]byte
+		trySaveAreaPool [][]uint64
 	}
 
 	// tryHandler records the state at a try_table entry for exception handling.
@@ -617,14 +624,28 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			info := &me.parent.tryTableInfo[tryTableID]
 			returnAddress := c.execCtx.goCallReturnAddress
 			oldTop, oldSp := c.stackTop, uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall))
-			newSP, newFP, newTop, newStack := c.cloneStack(uintptr(len(c.stack)) + 16)
+			needLen := uintptr(len(c.stack)) + 16
+			var newSP, newFP, newTop uintptr
+			var newStack []byte
+			if newStack = c.takePooledTryStack(needLen); newStack != nil {
+				newSP, newFP, newTop = c.cloneStackInto(newStack)
+			} else {
+				newSP, newFP, newTop, newStack = c.cloneStack(needLen)
+			}
 			adjustClonedStack(oldSp, oldTop, newSP, newFP, newTop)
 
 			// Allocate a heap buffer for locals so handlers can read throw-time values.
 			// Nested try_tables in the same function (ReuseLocals) share the enclosing handler's save area.
 			var saveArea []uint64
 			if info.NumLocals > 0 && !info.ReuseLocals {
-				saveArea = make([]uint64, info.NumLocals*2) // 16 bytes per local
+				need := info.NumLocals * 2 // 16 bytes per local
+				if n := len(c.trySaveAreaPool); n > 0 && cap(c.trySaveAreaPool[n-1]) >= need {
+					saveArea = c.trySaveAreaPool[n-1][:need]
+					c.trySaveAreaPool = c.trySaveAreaPool[:n-1]
+					clear(saveArea)
+				} else {
+					saveArea = make([]uint64, need)
+				}
 				c.execCtx.localsSaveAreaPtr = uintptr(unsafe.Pointer(&saveArea[0]))
 			}
 
@@ -648,9 +669,10 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 		case wazevoapi.ExitCodeTryTableLeave:
 			// Pop the most recent try handler and restore the locals save
 			// area pointer from the handler below (or clear it).
-			if len(c.tryHandlers) > 0 {
-				c.tryHandlers = c.tryHandlers[:len(c.tryHandlers)-1]
-				c.restoreLocalsSaveAreaPtr(len(c.tryHandlers) - 1)
+			if n := len(c.tryHandlers); n > 0 {
+				c.poolTryHandlerBuffers(&c.tryHandlers[n-1])
+				c.tryHandlers = c.tryHandlers[:n-1]
+				c.restoreLocalsSaveAreaPtr(n - 2)
 			}
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
 			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
@@ -685,14 +707,24 @@ func (c *callEngine) doHandleException(exn *wasm.Exception) bool {
 				// the nearest enclosing one (same-function reuse).
 				c.restoreLocalsSaveAreaPtr(i)
 
-				// Pop all handlers at and above this one.
+				// Pop all handlers at and above this one. Handlers strictly
+				// above the match can never be restored again, so their
+				// buffers go back to the pools. The matched handler's own
+				// buffers must NOT be pooled: its cloned stack becomes the
+				// live stack below, and its locals save area may still be
+				// referenced through localsSaveAreaPtr.
+				for j := i + 1; j < len(c.tryHandlers); j++ {
+					c.poolTryHandlerBuffers(&c.tryHandlers[j])
+				}
 				c.tryHandlers = c.tryHandlers[:i]
 
 				// Store the caught exception so handler code can read params.
 				c.pendingException = exn
 
-				// Restore the cloned stack (like snapshot.doRestore).
+				// Restore the cloned stack (like snapshot.doRestore). The
+				// replaced live stack becomes reusable for future enters.
 				spp := *(**uint64)(unsafe.Pointer(&h.sp))
+				c.tryStackPool = append(c.tryStackPool, c.stack)
 				c.stack = h.stack
 				c.stackTop = h.top
 				ec := &c.execCtx
@@ -758,9 +790,45 @@ func (c *callEngine) growStack() (newSP, newFP uintptr, err error) {
 	return
 }
 
+// takePooledTryStack pops a pooled stack buffer with capacity of at least l,
+// or returns nil when none fits. Undersized buffers (the engine stack grew
+// since they were pooled) are discarded.
+func (c *callEngine) takePooledTryStack(l uintptr) []byte {
+	for n := len(c.tryStackPool); n > 0; n-- {
+		buf := c.tryStackPool[n-1]
+		c.tryStackPool[n-1] = nil
+		c.tryStackPool = c.tryStackPool[:n-1]
+		if uintptr(cap(buf)) >= l {
+			return buf[:l]
+		}
+	}
+	return nil
+}
+
+// poolTryHandlerBuffers returns the handler's buffers to the free lists and
+// clears the handler's references so the slice element does not keep them
+// reachable (and no longer aliases the pooled buffers).
+func (c *callEngine) poolTryHandlerBuffers(h *tryHandler) {
+	if h.stack != nil {
+		c.tryStackPool = append(c.tryStackPool, h.stack)
+		h.stack = nil
+	}
+	if h.localsSaveArea != nil {
+		c.trySaveAreaPool = append(c.trySaveAreaPool, h.localsSaveArea)
+		h.localsSaveArea = nil
+	}
+}
+
 func (c *callEngine) cloneStack(l uintptr) (newSP, newFP, newTop uintptr, newStack []byte) {
 	newStack = make([]byte, l)
+	newSP, newFP, newTop = c.cloneStackInto(newStack)
+	return
+}
 
+// cloneStackInto copies the live stack contents into newStack, like
+// cloneStack, but into a caller-provided buffer (e.g. one reused from
+// tryStackPool).
+func (c *callEngine) cloneStackInto(newStack []byte) (newSP, newFP, newTop uintptr) {
 	relSp := c.stackTop - uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall))
 	relFp := c.stackTop - c.execCtx.framePointerBeforeGoCall
 

--- a/internal/engine/wazevo/isa_amd64.go
+++ b/internal/engine/wazevo/isa_amd64.go
@@ -3,6 +3,8 @@
 package wazevo
 
 import (
+	"unsafe"
+
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend/isa/amd64"
 )
@@ -27,4 +29,27 @@ func goCallStackView(stackPointerBeforeGoCall *uint64) []uint64 {
 // More precisely, absolute addresses (frame pointers) in the stack must be adjusted.
 func adjustClonedStack(oldsp, oldTop, sp, fp, top uintptr) {
 	amd64.AdjustClonedStack(oldsp, oldTop, sp, fp, top)
+}
+
+// trampolineWindowBytes returns the size of the trampoline-owned stack
+// region at a Go-call exit: everything between RSP (stackPointerBeforeGoCall)
+// and the caller's stack pointer, i.e. the slice-size slot, the (16-byte
+// aligned) arg/ret area, and the Caller_RBP + Return Addr slots at [fp] and
+// [fp+8] that the trampoline's `mov rsp, rbp; pop rbp; ret` epilogue reads on
+// resume. See the layout in backend/isa/amd64/abi_go_call.go
+// CompileGoFunctionTrampoline.
+func trampolineWindowBytes(sp *uint64, fp uintptr) uintptr {
+	return fp + 16 - uintptr(unsafe.Pointer(sp))
+}
+
+// rebaseTrampolineWindow fixes stack-absolute values inside a restored
+// trampoline window after the stack buffer moved by topDelta (growStack
+// reallocation between the try_table entry and the throw). On amd64 the
+// window's Caller_RBP slot at [fp] holds an absolute pointer into the stack.
+func rebaseTrampolineWindow(sp *uint64, windowBytes, topDelta uintptr) {
+	if topDelta == 0 {
+		return
+	}
+	callerRBP := (*uint64)(unsafe.Add(unsafe.Pointer(sp), windowBytes-16))
+	*callerRBP += uint64(topDelta)
 }

--- a/internal/engine/wazevo/isa_arm64.go
+++ b/internal/engine/wazevo/isa_arm64.go
@@ -30,3 +30,18 @@ func adjustClonedStack(oldsp, oldTop, sp, fp, top uintptr) {
 	//  so no need to adjustment on arm64. However, when we make it absolute, which in my opinion is better perf-wise
 	//  at the expense of slightly costly stack growth, we need to adjust the pushed frame pointers.
 }
+
+// trampolineWindowBytes returns the size of the trampoline-owned stack
+// region at the given Go-call stack pointer: 16 bytes of frame info
+// (frame_size, sliceSize), the arg/ret area (frame_size, read from the
+// first slot), and 16 bytes of return address + size_of_arg_ret. See the
+// layout in backend/isa/arm64/abi_go_call.go.
+func trampolineWindowBytes(sp *uint64, _ uintptr) uintptr {
+	frameSize := *sp
+	return uintptr(16 + frameSize + 16)
+}
+
+// rebaseTrampolineWindow is a no-op on arm64: the trampoline window contains
+// no stack-absolute values (the saved return address is a code pointer and
+// frame sizes are relative), so a stack-buffer move needs no fix-up.
+func rebaseTrampolineWindow(*uint64, uintptr, uintptr) {}

--- a/internal/engine/wazevo/isa_other.go
+++ b/internal/engine/wazevo/isa_other.go
@@ -27,3 +27,11 @@ func goCallStackView(stackPointerBeforeGoCall *uint64) []uint64 {
 func adjustClonedStack(oldsp, oldTop, sp, fp, top uintptr) {
 	panic("unsupported architecture")
 }
+
+// trampolineWindowBytes returns the size of the trampoline-owned stack
+// region at the given Go-call stack pointer. Unused on unsupported
+// platforms (the compiler engine is unavailable).
+func trampolineWindowBytes(*uint64, uintptr) uintptr { return 0 }
+
+// rebaseTrampolineWindow is unused on unsupported platforms.
+func rebaseTrampolineWindow(*uint64, uintptr, uintptr) {}


### PR DESCRIPTION
Disclaimer: most of this work was done using Claude Fable with manual verification/guidance/planning by me.

## Design

### Problem

Entering a wasm `try_table` takes a checkpoint of the current execution state so a matching throw can unwind to it. The current implementation checkpoints by **cloning the entire call stack** (the same mechanism as `experimental.Snapshot`), allocating a fresh buffer every time. For exception-heavy modules — e.g. C++ compiled with wasm exceptions, where RAII-styled code enters `try_table` scopes constantly — this makes try_table entry both an allocator hot path and a memory-bandwidth hot path: rendering one alpha-compositing PDF page through an EH-enabled PDFium module allocated **49 MB across 4,731 allocations** in checkpoint clones alone.

### Change (two commits)

**Commit 1 — pool the checkpoint buffers.** Stack-clone buffers and locals save areas are recycled through per-call-engine free lists (`takePooledTryStack`, `trySaveAreaPool`) instead of being freshly allocated per `try_table` entry and dropped on exit. This removes steady-state allocation without changing what is stored.

**Commit 2 — stop cloning at all in the common case.** A checkpoint does not need a copy of the whole stack: as long as the live stack only *grows* deeper after the checkpoint (the normal case), the checkpoint state can be described by **offsets from the stack top** (`spOff`/`fpOff`) plus a small snapshot of the trampoline-owned window at the entry stack pointer (frame info + arg/ret area — bounded at 256 bytes, ISA-specific layout). On unwind, the offsets are re-anchored to the current stack top and the trampoline window is written back. Full clones remain in exactly one case: when the `experimental.Snapshot` API is enabled, since snapshot restores can rewind the stack to an earlier state, which would invalidate top-relative offsets — that case keeps the (now pooled) clone path.

### Fixes folded in during the rebase (the "failing tests")

**1. `checkptr` violations under `-race`.** The branch failed `-race` runs — not due to data races but **`checkptr` violations** (checkptr is enabled by `-race`): the new code read the trampoline window through bare `uintptr`→`unsafe.Pointer` conversions and a deprecated `reflect.SliceHeader` launder, at three sites (`trampolineWindowBytes` on both ISAs, the checkpoint snapshot, and the unwind restore). All three now derive their pointers from typed sources (`stackPointerBeforeGoCall *uint64`, `unsafe.Add` on the stack slice) — the idiom the surrounding upstream code already uses.

**2. amd64 was miscompiling every catch-after-a-call (CI: exception-handling spectests + `TestCppExceptions` failing with `unreachable`).** The offset-mode restore re-enters the try_table-enter trampoline's resume path, which on amd64 ends with `mov rsp, rbp; pop rbp; ret` — it reads **Caller_RBP from `[rbp]` and the return address from `[rbp+8]`, on the stack** (arm64 takes the resume return address from the execution context instead). The snapshot window was sized `8 + sizeInBytes` (slice-size slot + *unaligned* arg/ret area), which excludes the alignment padding and those two slots — and any call between the try_table entry and the throw overwrites exactly them (the next `call` pushes its return address at the same stack depth). The window is now computed as `fp + 16 − sp`, the exact trampoline-owned span from the Go-call stack pointer up to and including the Caller_RBP/Return-Addr pair (`trampolineWindowBytes` takes `framePointerBeforeGoCall` as a second argument).

**3. amd64 stale absolute frame pointer after stack growth.** The snapshotted Caller_RBP is an *absolute* pointer into the stack buffer; if `growStack` reallocates the stack between entry and throw, the restored value would dangle (this is the same amd64-only concern that makes upstream `adjustClonedStack` a no-op on arm64 but real on amd64). Offset-mode checkpoints now record the entry-time stack top, and a new per-ISA `rebaseTrampolineWindow` hook rebases the Caller_RBP slot by the stack-top delta on restore (no-op on arm64: its window holds no stack-absolute values).

**4. riscv64 (and every non-amd64/arm64 arch) failed to build**: the `isa_other.go` stub had kept the old `trampolineWindowBytes` signature. Fixed, and cross-builds of linux/riscv64, linux/386, and windows/amd64 verified.

## Correctness

- Full spectest matrix passes on **both arm64 (native) and amd64 (verified locally under Rosetta 2)**: v1, v2, **exception-handling**, threads, tail-call, typed-function-references, extended-const. The amd64 exception-handling suite and `experimental` `TestCppExceptions` failed before fix 2 above.
- `-race` (with checkptr): exception-handling spectests, `experimental`, wazevo unit tests, and `integration_test/engine` all pass (these failed before fix 1 above).
- `integration_test/engine` passes on amd64 as well.
- Cross-builds verified for linux/riscv64, linux/386, windows/amd64.
- A downstream golden-hash corpus (EH-enabled PDFium rendering 32 verified outputs) is unchanged.

## Measured performance (Apple M5, arm64; benchstat n=6, interleaved; base = main @ ab01134c)

### PDF rendering (go-pdfium: EH-enabled PDFium-as-wasm, open + render at 200 DPI + close)

**Allocations — the headline.** Per rendered page:

```
                          B/op (before)   B/op (after)              allocs/op
alpha_channel.pdf         50,285 Ki   →   1.7 Ki   (-100.0%)        4731 → 34  (-99.3%)
image_page.pdf            42,941 Ki   →   1.7 Ki   (-100.0%)        4040 → 34  (-99.2%)
invoice A                 15,516 Ki   →   1.7 Ki    (-99.99%)       1503 → 34  (-97.7%)
mona.pdf                   2,639 Ki   →   1.7 Ki    (-99.94%)        280 → 34  (-87.9%)
geomean                      433 Ki   →   1.7 Ki    (-99.6%)         255 → 34  (-86.7%)
```

Every document converges to the same fixed ~1.7 KiB / 34 allocations per render — the checkpoint traffic is gone entirely; what remains is per-call harness overhead.

**Time:** geomean **−2.54%**:

```
Wasm/mona.pdf-10          551.8µ ± 2%   523.2µ ± 6%  -5.19% (p=0.002)
Wasm/invoice-a.pdf-10     9.596m ± 2%   9.288m ± 3%  -3.21% (p=0.009)
Wasm/building_plan.pdf-10 3.212m ± 4%   3.120m ± 2%  -2.84% (p=0.041)
Wasm/rect-wrong.pdf-10    29.56m ±12%   28.75m ± 4%  -2.74% (p=0.026)
Wasm/image_page.pdf-10    102.3m ± 5%   100.2m ± 1%  -2.08% (p=0.002)
```

The time win is smaller than the allocation win because Go's allocator is fast; the deeper benefit is the removed GC pressure — 50 MB/render of garbage no longer competes with the application's own heap, which matters most in long-running services rendering many documents concurrently.

### wazero's own benchmark suite

Neutral (time geomean −0.4%, B/op geomean −0.3%; scattered sub-µs movers in both directions). Expected: the suite contains no exception-handling workloads, and the changed code only runs on `try_table` entry/unwind.

### Zig stdlib suite (`internal/integration_test/stdlibs`, Zig 0.11.0)

Neutral (all rows n.s., geomean −0.25%) — the Zig test binaries are built without wasm exception handling.

## Notes for review

- Behavior with `experimental.Snapshot` enabled is unchanged by design (full clones, now pooled): top-relative offsets cannot survive a snapshot restore that rewinds the stack.
- The trampoline-window layout knowledge is isolated in per-ISA `trampolineWindowBytes`/`rebaseTrampolineWindow` (arm64: frame info + arg/ret + return-address block, no absolute values; amd64: size slot + aligned arg/ret + Caller_RBP/Return-Addr, with the Caller_RBP slot rebased if the stack buffer moved), mirroring where `GoCallStackView`/`AdjustClonedStack` already encode the same per-ISA layout facts.
- The pool is per-call-engine and therefore goroutine-confined, same lifecycle as the stack itself; no synchronization is added.

