### PR TITLE
wazevo: guard-page-backed linear memory (checkless codegen) with an opt-in cgo fault handler

### DIFF
--- a/experimental/guard_memory.go
+++ b/experimental/guard_memory.go
@@ -1,0 +1,35 @@
+package experimental
+
+import (
+	"context"
+
+	"github.com/tetratelabs/wazero/internal/expctxkeys"
+)
+
+// WithGuardPageMemory enables guard-page-backed linear memory.
+//
+// When enabled, linear memories are placed in a large reserved virtual
+// region (covering the whole 32-bit wasm address space plus the maximum
+// static offset) whose uncommitted portion is inaccessible. Out-of-bounds
+// accesses are then caught by the hardware via a recoverable fault instead
+// of explicit per-access bounds checks, which lets the optimizing compiler
+// omit those checks entirely. Out-of-bounds accesses still trap with the
+// exact same error as before. This mirrors the virtual-memory technique
+// used by other WebAssembly runtimes and can substantially speed up
+// memory-intensive workloads.
+//
+// Notes:
+//   - The returned context must be passed to both wazero.NewRuntimeWithConfig
+//     (it configures the compiler) and module instantiation (it configures
+//     the memory allocation). Mismatches fail instantiation rather than run
+//     without the safety property.
+//   - Only supported with the optimizing compiler on 64-bit unix-like
+//     platforms; elsewhere it is silently ignored and the regular
+//     bounds-checked code is generated.
+//   - Shared (threads) memories are not supported yet and fall back to
+//     bounds-checked code.
+//   - Address space, not physical memory, is reserved (8 GiB + guard tail
+//     per memory instance).
+func WithGuardPageMemory(ctx context.Context) context.Context {
+	return context.WithValue(ctx, expctxkeys.GuardPageMemoryKey{}, true)
+}

--- a/experimental/guardsig/doc.go
+++ b/experimental/guardsig/doc.go
@@ -1,0 +1,31 @@
+// Package guardsig provides the optional, cgo-based hardware-fault handler
+// that makes guard-page-backed linear memory (see
+// experimental.WithGuardPageMemory) effective with the optimizing compiler.
+//
+// Guard-page memory lets the compiler omit per-access bounds checks: an
+// out-of-bounds guest access lands in an inaccessible reserved region and
+// faults. The Go runtime cannot recover a fault raised at a JIT program
+// counter, so this package installs a C signal handler — via a C constructor
+// that runs before the Go runtime initializes, which is the condition under
+// which the Go runtime forwards synchronous signals occurring in non-Go code
+// to a pre-existing handler. The handler classifies the fault (address inside
+// a registered guard region, stack pointer inside a registered wasm call
+// stack) and redirects the thread to a compiled exit sequence that reports
+// the regular wasm out-of-bounds trap. Faults that are not guest
+// out-of-bounds accesses are re-raised with the default action.
+//
+// Usage: blank-import this package and enable guard-page memory:
+//
+//	import _ "github.com/tetratelabs/wazero/experimental/guardsig"
+//
+//	ctx := experimental.WithGuardPageMemory(context.Background())
+//	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())
+//	// pass ctx to InstantiateModule as well.
+//
+// When this package is not imported, or cgo is disabled, or the platform is
+// unsupported, WithGuardPageMemory silently degrades to the regular
+// bounds-checked code generation: programs behave identically either way.
+//
+// Importing this package makes the enclosing program a cgo program. The
+// wazero module itself remains pure Go unless this package is imported.
+package guardsig

--- a/experimental/guardsig/guardsig.go
+++ b/experimental/guardsig/guardsig.go
@@ -1,0 +1,311 @@
+//go:build cgo && (darwin || linux) && (amd64 || arm64)
+
+package guardsig
+
+/*
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <string.h>
+
+// Registries shared with the signal handler. Writers (Go, via the exported
+// functions below) serialize on a mutex; the handler reads lock-free. The
+// key field (base / lo) of a slot is written last with release semantics and
+// read first with acquire semantics, so a handler that observes a non-zero
+// key observes the other fields of that registration.
+
+#define WZ_GS_MAX_REGIONS 512
+#define WZ_GS_MAX_STACKS 8192
+
+typedef struct {
+	_Atomic uintptr_t base;
+	uintptr_t end;
+} wz_gs_region;
+
+typedef struct {
+	_Atomic uintptr_t lo;
+	uintptr_t hi;
+	uintptr_t execctx;
+	uintptr_t exitseq;
+} wz_gs_stack;
+
+static wz_gs_region wz_gs_regions[WZ_GS_MAX_REGIONS];
+static wz_gs_stack wz_gs_stacks[WZ_GS_MAX_STACKS];
+static struct sigaction wz_gs_prev_segv, wz_gs_prev_bus;
+static int wz_gs_ok = 0;
+
+// ---- ucontext accessors ---------------------------------------------------
+//
+// The handler needs the faulting thread's SP (to identify the wasm call
+// stack, and with it the execution context), and rewrites PC to the engine's
+// guard-fault exit sequence with the execution context pointer and the
+// faulting PC placed in the registers that sequence expects
+// (arm64: x0/x1, amd64: rax/rcx).
+
+#if defined(__APPLE__) && defined(__aarch64__)
+#include <sys/ucontext.h>
+static uintptr_t wz_gs_uc_sp(void *ucv) {
+	return (uintptr_t)__darwin_arm_thread_state64_get_sp(((ucontext_t *)ucv)->uc_mcontext->__ss);
+}
+static uintptr_t wz_gs_uc_pc(void *ucv) {
+	return (uintptr_t)__darwin_arm_thread_state64_get_pc(((ucontext_t *)ucv)->uc_mcontext->__ss);
+}
+static void wz_gs_uc_redirect(void *ucv, uintptr_t exitseq, uintptr_t execctx, uintptr_t faultpc) {
+	ucontext_t *uc = (ucontext_t *)ucv;
+	uc->uc_mcontext->__ss.__x[0] = execctx;
+	uc->uc_mcontext->__ss.__x[1] = faultpc;
+	__darwin_arm_thread_state64_set_pc_fptr(uc->uc_mcontext->__ss, (void *)exitseq);
+}
+#elif defined(__APPLE__) && defined(__x86_64__)
+#include <sys/ucontext.h>
+static uintptr_t wz_gs_uc_sp(void *ucv) {
+	return (uintptr_t)((ucontext_t *)ucv)->uc_mcontext->__ss.__rsp;
+}
+static uintptr_t wz_gs_uc_pc(void *ucv) {
+	return (uintptr_t)((ucontext_t *)ucv)->uc_mcontext->__ss.__rip;
+}
+static void wz_gs_uc_redirect(void *ucv, uintptr_t exitseq, uintptr_t execctx, uintptr_t faultpc) {
+	ucontext_t *uc = (ucontext_t *)ucv;
+	uc->uc_mcontext->__ss.__rax = execctx;
+	uc->uc_mcontext->__ss.__rcx = faultpc;
+	uc->uc_mcontext->__ss.__rip = exitseq;
+}
+#elif defined(__linux__) && defined(__aarch64__)
+#include <ucontext.h>
+static uintptr_t wz_gs_uc_sp(void *ucv) {
+	return (uintptr_t)((ucontext_t *)ucv)->uc_mcontext.sp;
+}
+static uintptr_t wz_gs_uc_pc(void *ucv) {
+	return (uintptr_t)((ucontext_t *)ucv)->uc_mcontext.pc;
+}
+static void wz_gs_uc_redirect(void *ucv, uintptr_t exitseq, uintptr_t execctx, uintptr_t faultpc) {
+	ucontext_t *uc = (ucontext_t *)ucv;
+	uc->uc_mcontext.regs[0] = execctx;
+	uc->uc_mcontext.regs[1] = faultpc;
+	uc->uc_mcontext.pc = exitseq;
+}
+#elif defined(__linux__) && defined(__x86_64__)
+#include <ucontext.h>
+static uintptr_t wz_gs_uc_sp(void *ucv) {
+	return (uintptr_t)((ucontext_t *)ucv)->uc_mcontext.gregs[REG_RSP];
+}
+static uintptr_t wz_gs_uc_pc(void *ucv) {
+	return (uintptr_t)((ucontext_t *)ucv)->uc_mcontext.gregs[REG_RIP];
+}
+static void wz_gs_uc_redirect(void *ucv, uintptr_t exitseq, uintptr_t execctx, uintptr_t faultpc) {
+	ucontext_t *uc = (ucontext_t *)ucv;
+	uc->uc_mcontext.gregs[REG_RAX] = (greg_t)execctx;
+	uc->uc_mcontext.gregs[REG_RCX] = (greg_t)faultpc;
+	uc->uc_mcontext.gregs[REG_RIP] = (greg_t)exitseq;
+}
+#endif
+
+// ---- the handler ----------------------------------------------------------
+
+static void wz_gs_handler(int sig, siginfo_t *info, void *uc) {
+	uintptr_t addr = (uintptr_t)info->si_addr;
+	int i;
+	for (i = 0; i < WZ_GS_MAX_REGIONS; i++) {
+		uintptr_t base = atomic_load_explicit(&wz_gs_regions[i].base, memory_order_acquire);
+		if (base == 0 || addr < base || addr >= wz_gs_regions[i].end) {
+			continue;
+		}
+		// The fault address is inside a guard region. If the thread is
+		// executing wasm (SP inside a registered call stack), this is a
+		// guest out-of-bounds access: redirect to the exit sequence.
+		{
+			uintptr_t sp = wz_gs_uc_sp(uc);
+			int j;
+			for (j = 0; j < WZ_GS_MAX_STACKS; j++) {
+				uintptr_t lo = atomic_load_explicit(&wz_gs_stacks[j].lo, memory_order_acquire);
+				if (lo != 0 && sp >= lo && sp < wz_gs_stacks[j].hi) {
+					wz_gs_uc_redirect(uc, wz_gs_stacks[j].exitseq, wz_gs_stacks[j].execctx, wz_gs_uc_pc(uc));
+					return;
+				}
+			}
+		}
+		break;
+	}
+
+	// Not a guest out-of-bounds access. Chain to the handler that was
+	// installed before us if any; otherwise restore the default action and
+	// return, so the fault re-triggers and the process dies with the
+	// correct signal disposition.
+	{
+		struct sigaction *prev = (sig == SIGBUS) ? &wz_gs_prev_bus : &wz_gs_prev_segv;
+		if ((prev->sa_flags & SA_SIGINFO) != 0 && prev->sa_sigaction != NULL) {
+			prev->sa_sigaction(sig, info, uc);
+			return;
+		}
+		if (prev->sa_handler == SIG_IGN) {
+			return;
+		}
+		if (prev->sa_handler != SIG_DFL && prev->sa_handler != NULL) {
+			prev->sa_handler(sig);
+			return;
+		}
+		signal(sig, SIG_DFL);
+	}
+}
+
+// wz_gs_install is called from the package's Go init function, i.e. after
+// the Go runtime installed its own signal handlers. Our handler becomes the
+// primary one and chains to the saved Go runtime handler for every fault
+// that is not a guest out-of-bounds access, which is the interposition
+// pattern documented in os/signal ("Non-Go programs that call Go code" /
+// "If the non-Go code installs any signal handlers after the Go runtime is
+// initialized, it must save the existing Go signal handler and call it").
+// Going through the Go runtime's forwarding in the other direction is not
+// possible here: the runtime only forwards synchronous signals raised on
+// non-Go threads or inside cgo calls, and JIT-compiled wasm code runs on
+// ordinary goroutines.
+static int wz_gs_install(void) {
+	struct sigaction sa;
+	if (wz_gs_ok) {
+		return 1;
+	}
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_sigaction = wz_gs_handler;
+	sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+	sigemptyset(&sa.sa_mask);
+	if (sigaction(SIGSEGV, &sa, &wz_gs_prev_segv) != 0) {
+		return 0;
+	}
+	if (sigaction(SIGBUS, &sa, &wz_gs_prev_bus) != 0) {
+		sigaction(SIGSEGV, &wz_gs_prev_segv, NULL);
+		return 0;
+	}
+	wz_gs_ok = 1;
+	return 1;
+}
+
+// ---- accessors (called from Go) --------------------------------------------
+//
+// Registration is done by Go code writing directly into these C-owned tables
+// (see the Go side below): a cgo call per registration would dominate
+// embedders that create many short-lived call engines. The write protocol is
+// unchanged: non-key fields first, then the key field with a release store,
+// which pairs with the handler's acquire load.
+
+static int wazero_guardsig_install_go(void) { return wz_gs_install(); }
+
+static void *wazero_guardsig_region_table(void) { return wz_gs_regions; }
+
+static void *wazero_guardsig_stack_table(void) { return wz_gs_stacks; }
+
+*/
+import "C"
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/tetratelabs/wazero/internal/platform"
+)
+
+const (
+	maxRegions = 512  // must match WZ_GS_MAX_REGIONS
+	maxStacks  = 8192 // must match WZ_GS_MAX_STACKS
+)
+
+// regionSlot/stackSlot mirror the C structs. The key field (base/lo) is
+// accessed atomically; a slot with key 0 is free.
+type (
+	regionSlot struct{ base, end uintptr }
+	stackSlot  struct{ lo, hi, execctx, exitseq uintptr }
+)
+
+// The registries live in C static memory (async-signal-safe for the handler,
+// exempt from checkptr/GC concerns for Go). Go writes them directly — no cgo
+// call on the registration path.
+var (
+	mu          sync.Mutex
+	regions     []regionSlot
+	stacks      []stackSlot
+	regionFree  []int32
+	stackFree   []int32
+	regionIndex map[uintptr]int32
+	stackIndex  map[uintptr]int32
+)
+
+func init() {
+	if C.wazero_guardsig_install_go() == 0 {
+		return
+	}
+	regions = unsafe.Slice((*regionSlot)(C.wazero_guardsig_region_table()), maxRegions)
+	stacks = unsafe.Slice((*stackSlot)(C.wazero_guardsig_stack_table()), maxStacks)
+	regionFree = make([]int32, 0, maxRegions)
+	for i := int32(maxRegions - 1); i >= 0; i-- {
+		regionFree = append(regionFree, i)
+	}
+	stackFree = make([]int32, 0, maxStacks)
+	for i := int32(maxStacks - 1); i >= 0; i-- {
+		stackFree = append(stackFree, i)
+	}
+	regionIndex = make(map[uintptr]int32)
+	stackIndex = make(map[uintptr]int32)
+
+	platform.SetGuardFaultHandlerHooks(
+		func() bool { return true },
+		regionAdd, regionDel, stackAdd, stackDel,
+	)
+}
+
+func regionAdd(base, end uintptr) bool {
+	mu.Lock()
+	defer mu.Unlock()
+	n := len(regionFree)
+	if n == 0 {
+		return false
+	}
+	i := regionFree[n-1]
+	regionFree = regionFree[:n-1]
+	regionIndex[base] = i
+	s := &regions[i]
+	s.end = end
+	atomic.StoreUintptr(&s.base, base) // release: publish after fields
+	return true
+}
+
+func regionDel(base uintptr) {
+	mu.Lock()
+	defer mu.Unlock()
+	if i, ok := regionIndex[base]; ok {
+		atomic.StoreUintptr(&regions[i].base, 0)
+		delete(regionIndex, base)
+		regionFree = append(regionFree, i)
+	}
+}
+
+func stackAdd(lo, hi, execCtx, exitSeq uintptr) bool {
+	mu.Lock()
+	defer mu.Unlock()
+	n := len(stackFree)
+	if n == 0 {
+		return false
+	}
+	i := stackFree[n-1]
+	stackFree = stackFree[:n-1]
+	stackIndex[lo] = i
+	s := &stacks[i]
+	s.hi = hi
+	s.execctx = execCtx
+	s.exitseq = exitSeq
+	atomic.StoreUintptr(&s.lo, lo) // release: publish after fields
+	return true
+}
+
+func stackDel(lo uintptr) {
+	mu.Lock()
+	defer mu.Unlock()
+	if i, ok := stackIndex[lo]; ok {
+		atomic.StoreUintptr(&stacks[i].lo, 0)
+		delete(stackIndex, lo)
+		stackFree = append(stackFree, i)
+	}
+}
+
+// Supported returns true when the fault handler is installed and guard-page
+// memory will therefore run without per-access bounds checks.
+func Supported() bool { return platform.GuardFaultHandlerInstalled() }

--- a/experimental/guardsig/guardsig_test.go
+++ b/experimental/guardsig/guardsig_test.go
@@ -1,0 +1,87 @@
+package guardsig_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/experimental/guardsig"
+	"github.com/tetratelabs/wazero/internal/testing/binaryencoding"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
+	"github.com/tetratelabs/wazero/internal/wasmruntime"
+)
+
+// testModule returns a module with a 1-page (max 2) memory exporting:
+//   - "load8" (param addr i32) (result i32): i32.load8_u
+//   - "load8drop" (param addr i32): i32.load8_u + drop (must still trap)
+//   - "grow" (param pages i32) (result i32): memory.grow
+func testModule() []byte {
+	two := uint32(2)
+	m := &wasm.Module{
+		TypeSection: []wasm.FunctionType{
+			{Params: []wasm.ValueType{wasm.ValueTypeI32}, Results: []wasm.ValueType{wasm.ValueTypeI32}},
+			{Params: []wasm.ValueType{wasm.ValueTypeI32}},
+		},
+		FunctionSection: []wasm.Index{0, 1, 0},
+		MemorySection:   &wasm.Memory{Min: 1, Cap: 1, Max: two, IsMaxEncoded: true},
+		CodeSection: []wasm.Code{
+			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeI32Load8U, 0, 0, wasm.OpcodeEnd}},
+			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeI32Load8U, 0, 0, wasm.OpcodeDrop, wasm.OpcodeEnd}},
+			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeMemoryGrow, 0, wasm.OpcodeEnd}},
+		},
+		ExportSection: []wasm.Export{
+			{Name: "load8", Type: wasm.ExternTypeFunc, Index: 0},
+			{Name: "load8drop", Type: wasm.ExternTypeFunc, Index: 1},
+			{Name: "grow", Type: wasm.ExternTypeFunc, Index: 2},
+		},
+	}
+	return binaryencoding.EncodeModule(m)
+}
+
+func TestGuardPageMemoryTraps(t *testing.T) {
+	if !guardsig.Supported() {
+		t.Skip("guard-fault handler unavailable")
+	}
+	ctx := experimental.WithGuardPageMemory(context.Background())
+	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())
+	defer r.Close(ctx)
+
+	mod, err := r.Instantiate(ctx, testModule())
+	require.NoError(t, err)
+
+	load8 := mod.ExportedFunction("load8")
+
+	// In bounds.
+	res, err := load8.Call(ctx, 0)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), res[0])
+	_, err = load8.Call(ctx, 65535)
+	require.NoError(t, err)
+
+	// Out of bounds: first byte past the memory, and far beyond.
+	for _, addr := range []uint64{65536, 65537, 100000, 1 << 20, 0xffffffff} {
+		_, err = load8.Call(ctx, addr)
+		require.True(t, errors.Is(err, wasmruntime.ErrRuntimeOutOfBoundsMemoryAccess), "addr=%d err=%v", addr, err)
+	}
+
+	// A load whose result is dropped must still trap.
+	_, err = mod.ExportedFunction("load8drop").Call(ctx, 65536)
+	require.True(t, errors.Is(err, wasmruntime.ErrRuntimeOutOfBoundsMemoryAccess), "dropped load err=%v", err)
+
+	// Growing commits more of the reservation; the boundary moves.
+	res, err = mod.ExportedFunction("grow").Call(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), res[0])
+	_, err = load8.Call(ctx, 65536) // now in bounds
+	require.NoError(t, err)
+	_, err = load8.Call(ctx, 131072) // new boundary
+	require.True(t, errors.Is(err, wasmruntime.ErrRuntimeOutOfBoundsMemoryAccess), "after grow err=%v", err)
+
+	// The engine still works for subsequent calls after many traps.
+	res, err = load8.Call(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), res[0])
+}

--- a/experimental/guardsig/guardsig_unsupported.go
+++ b/experimental/guardsig/guardsig_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !cgo || !((darwin || linux) && (amd64 || arm64))
+
+package guardsig
+
+// Supported returns false: without cgo (or on an unsupported platform) the
+// fault handler is unavailable, and guard-page memory silently falls back to
+// bounds-checked code generation.
+func Supported() bool { return false }

--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -2503,7 +2503,7 @@ L3 (SSA Block: blk3):
 
 			ssab := ssa.NewBuilder()
 			offset := wazevoapi.NewModuleContextOffsetData(tc.m, false)
-			fc := frontend.NewFrontendCompiler(tc.m, ssab, &offset, false, false, false)
+			fc := frontend.NewFrontendCompiler(tc.m, ssab, &offset, false, false, false, false)
 			machine := newMachine()
 			machine.DisableStackCheck()
 			be := backend.NewCompiler(context.Background(), machine, ssab)

--- a/internal/engine/wazevo/backend/isa/amd64/abi_go_call.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi_go_call.go
@@ -438,3 +438,40 @@ func (m *machine) insertStackBoundsCheck(requiredStackSize int64, cur *instructi
 
 	return cur
 }
+
+// CompileGuardFaultExitSequence implements backend.Machine.
+//
+// The guard-page fault handler redirects a faulting thread here with the
+// execution context pointer in rax and the faulting program counter in rcx.
+// The sequence records the trap exactly like an inline lowerExitWithCode
+// (exit code, RSP/RBP for unwinding, trap address for source mapping) and
+// then exits the wasm execution.
+func (m *machine) CompileGuardFaultExitSequence() []byte {
+	cur := m.allocateNop()
+	m.rootInstr = cur
+
+	execCtx := raxVReg
+	// RBP is saved into the execution context before it is reused as the
+	// scratch register for the exit code constant, same as lowerExitWithCode.
+	exitCodeReg := rbpVReg
+	saveRsp, saveRbp, setExitCode := m.allocateExitInstructions(execCtx, exitCodeReg)
+	cur = linkInstr(cur, saveRsp)
+	cur = linkInstr(cur, saveRbp)
+	cur = linkInstr(cur, m.allocateInstr().asImm(exitCodeReg, uint64(wazevoapi.ExitCodeMemoryOutOfBounds), false))
+	cur = linkInstr(cur, setExitCode)
+
+	// Store the faulting program counter (rcx) as the "return address" of
+	// this exit so stack traces point at the faulting wasm instruction.
+	storeFaultPC := m.allocateInstr().asMovRM(
+		rcxVReg,
+		newOperandMem(m.newAmodeImmReg(wazevoapi.ExecutionContextOffsetGoCallReturnAddress.U32(), execCtx)),
+		8,
+	)
+	cur = linkInstr(cur, storeFaultPC)
+
+	// Exit the execution.
+	linkInstr(cur, m.allocateExitSeq(execCtx))
+
+	m.encodeWithoutSSA(m.rootInstr)
+	return m.c.Buf()
+}

--- a/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue.go
@@ -563,3 +563,38 @@ func (m *machine) addsAddOrSubStackPointer(cur *instruction, rd regalloc.VReg, d
 	}
 	return cur
 }
+
+// CompileGuardFaultExitSequence implements backend.Machine.
+//
+// The guard-page fault handler redirects a faulting thread here with the
+// execution context pointer in x0 and the faulting program counter in x1.
+// The sequence records the trap exactly like an inline lowerExitWithCode
+// (exit code, stack pointer for unwinding, trap address for source mapping)
+// and then exits the wasm execution.
+func (m *machine) CompileGuardFaultExitSequence() []byte {
+	cur := m.allocateInstr()
+	cur.asNop0()
+	m.rootInstr = cur
+
+	// Set the exit status on the execution context (uses x17 as scratch).
+	cur = m.setExitCode(cur, x0VReg, wazevoapi.ExitCodeMemoryOutOfBounds)
+
+	// Save the current stack pointer for stack unwinding.
+	cur = m.saveCurrentStackPointer(cur, x0VReg)
+
+	// Store the faulting program counter (x1) as the "return address" of
+	// this exit so stack traces point at the faulting wasm instruction.
+	storeFaultPC := m.allocateInstr()
+	mode := m.amodePool.Allocate()
+	*mode = addressMode{kind: addressModeKindRegUnsignedImm12, rn: x0VReg, imm: wazevoapi.ExecutionContextOffsetGoCallReturnAddress.I64()}
+	storeFaultPC.asStore(operandNR(x1VReg), mode, 64)
+	cur = linkInstr(cur, storeFaultPC)
+
+	// Exit the execution.
+	exitSeq := m.allocateInstr()
+	exitSeq.asExitSequence(x0VReg)
+	linkInstr(cur, exitSeq)
+
+	m.encode(m.rootInstr)
+	return m.compiler.Buf()
+}

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -99,6 +99,13 @@ type (
 		// call the stack grow builtin function.
 		CompileStackGrowCallSequence() []byte
 
+		// CompileGuardFaultExitSequence returns the sequence of instructions that exits the wasm
+		// execution with ExitCodeMemoryOutOfBounds. When guard-page-backed memory is enabled, the
+		// signal handler redirects a faulting thread here with the execution context pointer and
+		// the faulting program counter placed in ISA-specific registers (arm64: x0 and x1,
+		// amd64: rax and rcx).
+		CompileGuardFaultExitSequence() []byte
+
 		// CompileEntryPreamble returns the sequence of instructions shared by multiple functions to
 		// enter the function from Go.
 		CompileEntryPreamble(signature *ssa.Signature) []byte

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -46,6 +46,11 @@ func (m mockMachine) CompileStackGrowCallSequence() []byte {
 	panic("TODO")
 }
 
+// CompileGuardFaultExitSequence implements backend.Machine.
+func (m mockMachine) CompileGuardFaultExitSequence() []byte {
+	panic("TODO")
+}
+
 // CompileGoFunctionTrampoline implements Machine.CompileGoFunctionTrampoline.
 func (m mockMachine) CompileGoFunctionTrampoline(wazevoapi.ExitCode, *ssa.Signature, bool) []byte {
 	panic("TODO")

--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	"runtime/debug"
 	"sync/atomic"
 	"unsafe"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi"
 	"github.com/tetratelabs/wazero/internal/expctxkeys"
 	"github.com/tetratelabs/wazero/internal/internalapi"
+	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasmdebug"
 	"github.com/tetratelabs/wazero/internal/wasmruntime"
@@ -49,6 +51,10 @@ type (
 		// pendingException holds the most recently caught exception, so handler
 		// code can read its params after re-entry.
 		pendingException *wasm.Exception
+		// guardStackLo is the base address of the stack range currently
+		// registered with the guard-fault signal handler (0 if none). Only
+		// used when the module was compiled for guard-page backed memory.
+		guardStackLo uintptr
 	}
 
 	// tryHandler records the state at a try_table entry for exception handling.
@@ -171,6 +177,45 @@ func (c *callEngine) init() {
 		c.execCtx.stackBottomPtr = &c.stack[0]
 	}
 	c.execCtxPtr = uintptr(unsafe.Pointer(&c.execCtx))
+	c.updateGuardStackRegistration()
+}
+
+// updateGuardStackRegistration (re)registers this call engine's stack range
+// with the guard-fault signal handler, so a hardware fault raised by the
+// checkless code running on this stack can be redirected to the guard-fault
+// exit sequence with the right execution context. Must be called whenever
+// c.stack changes identity. No-op unless the module was compiled for
+// guard-page backed memory (which implies the handler is installed).
+func (c *callEngine) updateGuardStackRegistration() {
+	if c.parent == nil || c.parent.parent == nil {
+		return // only happens in unit tests constructing a bare callEngine.
+	}
+	cm := c.parent.parent
+	if !cm.guardedMemory {
+		return
+	}
+	lo := uintptr(unsafe.Pointer(&c.stack[0]))
+	hi := lo + uintptr(len(c.stack))
+	if c.guardStackLo != 0 {
+		if c.guardStackLo == lo {
+			return
+		}
+		platform.GuardSigStackDel(c.guardStackLo)
+	} else {
+		// First registration: arrange for deregistration when this call
+		// engine is garbage collected.
+		runtime.SetFinalizer(c, func(c *callEngine) {
+			if c.guardStackLo != 0 {
+				platform.GuardSigStackDel(c.guardStackLo)
+			}
+		})
+	}
+	exitSeq := uintptr(unsafe.Pointer(cm.parent.sharedFunctions.guardFaultExitAddress))
+	if !platform.GuardSigStackAdd(lo, hi, c.execCtxPtr, exitSeq) {
+		c.guardStackLo = 0
+		panic("wazero: the guard-fault handler's stack registry is full; too many concurrent call engines with guard-page memory")
+	}
+	c.guardStackLo = lo
 }
 
 // alignedStackTop returns 16-bytes aligned stack top of given stack.
@@ -259,6 +304,13 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 	}
 
 	p := c.parent
+	if p.parent.guardedMemory {
+		// With guard-page backed memory, out-of-bounds accesses surface as
+		// hardware faults; make them recoverable panics so the deferred
+		// handler below can translate them to the regular wasm trap.
+		old := debug.SetPanicOnFault(true)
+		defer debug.SetPanicOnFault(old)
+	}
 	ensureTermination := p.parent.ensureTermination
 	m := p.module
 	if ensureTermination {
@@ -286,6 +338,13 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			panic(s)
 		}
 		if r != nil {
+			// A hardware fault inside a registered guard region is a guest
+			// out-of-bounds memory access (guard-page backed memory omits
+			// explicit bounds checks); translate it to the regular trap.
+			// Faults anywhere else keep propagating as runtime errors.
+			if fe, ok := r.(interface{ Addr() uintptr }); ok && platform.IsGuardRegionAddr(fe.Addr()) {
+				r = wasmruntime.ErrRuntimeOutOfBoundsMemoryAccess
+			}
 			type listenerForAbort struct {
 				def api.FunctionDefinition
 				lsn experimental.FunctionListener
@@ -695,6 +754,7 @@ func (c *callEngine) doHandleException(exn *wasm.Exception) bool {
 				spp := *(**uint64)(unsafe.Pointer(&h.sp))
 				c.stack = h.stack
 				c.stackTop = h.top
+				c.updateGuardStackRegistration()
 				ec := &c.execCtx
 				ec.stackBottomPtr = &c.stack[0]
 				ec.stackPointerBeforeGoCall = spp
@@ -755,6 +815,7 @@ func (c *callEngine) growStack() (newSP, newFP uintptr, err error) {
 	newLen := 2*currentLen + c.execCtx.stackGrowRequiredSize + 16 // Stack might be aligned to 16 bytes, so add 16 bytes just in case.
 	newSP, newFP, c.stackTop, c.stack = c.cloneStack(newLen)
 	c.execCtx.stackBottomPtr = &c.stack[0]
+	c.updateGuardStackRegistration()
 	return
 }
 
@@ -896,6 +957,7 @@ func (s *snapshot) doRestore() {
 	c := s.c
 	c.stack = s.stack
 	c.stackTop = s.top
+	c.updateGuardStackRegistration()
 	ec := &c.execCtx
 	ec.stackBottomPtr = &c.stack[0]
 	ec.stackPointerBeforeGoCall = spp

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/frontend"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi"
+	"github.com/tetratelabs/wazero/internal/expctxkeys"
 	"github.com/tetratelabs/wazero/internal/filecache"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/version"
@@ -45,6 +46,11 @@ type (
 		// The followings are reused for compiling shared functions.
 		machine backend.Machine
 		be      backend.Compiler
+
+		// guardedMemory is true when linear memories are guard-page backed
+		// (experimental.WithGuardPageMemory), letting the compiler omit
+		// per-access memory bounds checks.
+		guardedMemory bool
 	}
 
 	sharedFunctions struct {
@@ -76,7 +82,11 @@ type (
 		tryTableEnterAddress *byte
 		// tryTableLeaveAddress is the address of try_table leave trampoline.
 		tryTableLeaveAddress *byte
-		listenerTrampolines  listenerTrampolines
+		// guardFaultExitAddress is the address of the guard-fault exit sequence:
+		// the signal handler redirects a thread that faulted on a guard-page
+		// backed memory here to raise the out-of-bounds trap.
+		guardFaultExitAddress *byte
+		listenerTrampolines   listenerTrampolines
 	}
 
 	listenerTrampolines = map[*wasm.FunctionType]struct {
@@ -93,6 +103,7 @@ type (
 		parent                    *engine
 		module                    *wasm.Module
 		ensureTermination         bool
+		guardedMemory             bool
 		listeners                 []experimental.FunctionListener
 		listenerBeforeTrampolines []*byte
 		listenerAfterTrampolines  []*byte
@@ -130,7 +141,14 @@ var _ wasm.Engine = (*engine)(nil)
 func NewEngine(ctx context.Context, _ api.CoreFeatures, fc filecache.Cache) wasm.Engine {
 	machine := newMachine()
 	be := backend.NewCompiler(ctx, machine, ssa.NewBuilder())
+	guardedMemory, _ := ctx.Value(expctxkeys.GuardPageMemoryKey{}).(bool)
+	// Checkless code generation additionally requires the guard-fault signal
+	// handler (experimental/guardsig): the Go runtime cannot recover a fault
+	// raised at a JIT program counter, so without the handler we keep
+	// generating explicit bounds checks.
+	guardedMemory = guardedMemory && platform.GuardPageMemorySupported && platform.GuardFaultHandlerInstalled()
 	e := &engine{
+		guardedMemory:   guardedMemory,
 		compiledModules: make(map[wasm.ModuleID]*compiledModuleWithCount),
 		setFinalizer:    runtime.SetFinalizer,
 		machine:         machine,
@@ -234,6 +252,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 	cm := &compiledModule{
 		offsets: wazevoapi.NewModuleContextOffsetData(module, withListener), parent: e, module: module,
 		ensureTermination: ensureTermination,
+		guardedMemory:     e.guardedMemory,
 		executables:       &executables{},
 	}
 
@@ -263,7 +282,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 
 	if workers := experimental.GetCompilationWorkers(ctx); workers <= 1 {
 		// Compile with a single goroutine.
-		fe := frontend.NewFrontendCompiler(module, ssaBuilder, &cm.offsets, ensureTermination, withListener, needSourceInfo)
+		fe := frontend.NewFrontendCompiler(module, ssaBuilder, &cm.offsets, ensureTermination, withListener, needSourceInfo, e.guardedMemory)
 
 		for i := range module.CodeSection {
 			if wazevoapi.DeterministicCompilationVerifierEnabled {
@@ -317,7 +336,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 				ssaBuilder := ssa.NewBuilder()
 				be := backend.NewCompiler(ctx, machine, ssaBuilder)
 				fe := frontend.NewFrontendCompiler(
-					module, ssaBuilder, &cm.offsets, ensureTermination, withListener, needSourceInfo).
+					module, ssaBuilder, &cm.offsets, ensureTermination, withListener, needSourceInfo, e.guardedMemory).
 					WithTryTableMetadata(sharedTTM)
 
 				for {
@@ -739,6 +758,14 @@ func (e *engine) NewModuleEngine(m *wasm.Module, mi *wasm.ModuleInstance) (wasm.
 	me.module = mi
 	me.listeners = compiled.listeners
 
+	// A module compiled without per-access bounds checks must only run
+	// against a guard-page backed memory; refuse to pair otherwise.
+	if compiled.guardedMemory && mi.MemoryInstance != nil && !mi.MemoryInstance.GuardBacked {
+		return nil, errors.New("module was compiled with guard-page memory " +
+			"(experimental.WithGuardPageMemory) but the memory instance is not guard-page backed; " +
+			"pass the same context to instantiation")
+	}
+
 	if m.IsHostModule {
 		me.opaque = buildHostModuleOpaque(m, compiled.listeners)
 		me.opaquePtr = &me.opaque[0]
@@ -753,7 +780,7 @@ func (e *engine) NewModuleEngine(m *wasm.Module, mi *wasm.ModuleInstance) (wasm.
 }
 
 func (e *engine) compileSharedFunctions() {
-	var sizes [12]int
+	var sizes [13]int
 	var trampolines []byte
 
 	addTrampoline := func(i int, buf []byte) {
@@ -853,6 +880,9 @@ func (e *engine) compileSharedFunctions() {
 			Results: []ssa.Type{},
 		}, false))
 
+	e.be.Init()
+	addTrampoline(12, e.machine.CompileGuardFaultExitSequence())
+
 	fns := &sharedFunctions{
 		executable:          mmapExecutable(trampolines),
 		listenerTrampolines: make(listenerTrampolines),
@@ -883,6 +913,8 @@ func (e *engine) compileSharedFunctions() {
 	fns.tryTableEnterAddress = &fns.executable[offset]
 	offset += sizes[10]
 	fns.tryTableLeaveAddress = &fns.executable[offset]
+	offset += sizes[11]
+	fns.guardFaultExitAddress = &fns.executable[offset]
 
 	if wazevoapi.PerfMapEnabled {
 		wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(fns.memoryGrowAddress)), uint64(sizes[0]), "memory_grow_trampoline")

--- a/internal/engine/wazevo/engine_cache.go
+++ b/internal/engine/wazevo/engine_cache.go
@@ -26,10 +26,17 @@ var crc = crc32.MakeTable(crc32.Castagnoli)
 // fileCacheKey returns a key for the file cache.
 // In order to avoid collisions with the existing compiler, we do not use m.ID directly,
 // but instead we rehash it with magic.
-func fileCacheKey(m *wasm.Module) (ret filecache.Key) {
+func fileCacheKey(m *wasm.Module, guardedMemory bool) (ret filecache.Key) {
 	s := sha256.New()
 	s.Write(m.ID[:])
 	s.Write(magic)
+	// Guarded-memory compilation omits bounds checks, so its artifacts must
+	// not be mixed with regular ones.
+	if guardedMemory {
+		s.Write([]byte{1})
+	} else {
+		s.Write([]byte{0})
+	}
 	// Write the CPU features so that we can cache the compiled module for the same CPU.
 	// This prevents the incompatible CPU features from being used.
 	cpu := platform.CpuFeatures.Raw()
@@ -116,7 +123,7 @@ func (e *engine) addCompiledModuleToCache(module *wasm.Module, cm *compiledModul
 	if e.fileCache == nil || module.IsHostModule {
 		return
 	}
-	err = e.fileCache.Add(fileCacheKey(module), serializeCompiledModule(e.wazeroVersion, cm))
+	err = e.fileCache.Add(fileCacheKey(module, e.guardedMemory), serializeCompiledModule(e.wazeroVersion, cm))
 	return
 }
 
@@ -127,7 +134,7 @@ func (e *engine) getCompiledModuleFromCache(module *wasm.Module) (cm *compiledMo
 
 	// Check if the entries exist in the external cache.
 	var cached io.ReadCloser
-	cached, hit, err = e.fileCache.Get(fileCacheKey(module))
+	cached, hit, err = e.fileCache.Get(fileCacheKey(module, e.guardedMemory))
 	if !hit || err != nil {
 		return
 	}
@@ -141,7 +148,7 @@ func (e *engine) getCompiledModuleFromCache(module *wasm.Module) (cm *compiledMo
 		hit = false
 		return
 	} else if staleCache {
-		return nil, false, e.fileCache.Delete(fileCacheKey(module))
+		return nil, false, e.fileCache.Delete(fileCacheKey(module, e.guardedMemory))
 	}
 	return
 }

--- a/internal/engine/wazevo/engine_cache_test.go
+++ b/internal/engine/wazevo/engine_cache_test.go
@@ -322,7 +322,7 @@ func Test_fileCacheKey(t *testing.T) {
 	m := &wasm.Module{}
 	s.Sum(m.ID[:0])
 	original := m.ID
-	result := fileCacheKey(m)
+	result := fileCacheKey(m, false)
 	require.Equal(t, original, m.ID)
 	require.NotEqual(t, original, result)
 }

--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -31,6 +31,9 @@ type Compiler struct {
 	refFuncSig             ssa.Signature
 	memmoveSig             ssa.Signature
 	ensureTermination      bool
+	// memoryGuarded is true when linear memory is guard-page backed, so
+	// per-access bounds checks can be omitted (see memOpSetup).
+	memoryGuarded bool
 
 	// Followings are reset by per function.
 
@@ -106,13 +109,14 @@ type (
 var knownSafeBoundsAtTheEndOfBlockNil = wazevoapi.NewNilVarLength[knownSafeBoundWithID]()
 
 // NewFrontendCompiler returns a frontend Compiler.
-func NewFrontendCompiler(m *wasm.Module, ssaBuilder ssa.Builder, offset *wazevoapi.ModuleContextOffsetData, ensureTermination bool, listenerOn bool, sourceInfo bool) *Compiler {
+func NewFrontendCompiler(m *wasm.Module, ssaBuilder ssa.Builder, offset *wazevoapi.ModuleContextOffsetData, ensureTermination bool, listenerOn bool, sourceInfo bool, memoryGuarded bool) *Compiler {
 	c := &Compiler{
 		m:                                 m,
 		ssaBuilder:                        ssaBuilder,
 		br:                                bytes.NewReader(nil),
 		offset:                            offset,
 		ensureTermination:                 ensureTermination,
+		memoryGuarded:                     memoryGuarded,
 		needSourceOffsetInfo:              sourceInfo,
 		tryTableMetadata:                  &localTryTableMetadata{},
 		varLengthKnownSafeBoundWithIDPool: wazevoapi.NewVarLengthPool[knownSafeBoundWithID](),

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -3004,7 +3004,7 @@ blk9: () <-- (blk4)
 			b := ssa.NewBuilder()
 
 			offset := wazevoapi.NewModuleContextOffsetData(tc.m, tc.needListener)
-			fc := NewFrontendCompiler(tc.m, b, &offset, tc.ensureTermination, tc.needListener, false)
+			fc := NewFrontendCompiler(tc.m, b, &offset, tc.ensureTermination, tc.needListener, false, false)
 			typeIndex := tc.m.FunctionSection[tc.targetIndex]
 			code := &tc.m.CodeSection[tc.targetIndex]
 			fc.Init(tc.targetIndex, typeIndex, &tc.m.TypeSection[typeIndex], code.LocalTypes, code.Body, tc.needListener, 0)
@@ -3222,7 +3222,7 @@ func TestKnownSafeBound_valid(t *testing.T) {
 }
 
 func TestCompiler_finalizeKnownSafeBoundsAtTheEndOoBlock(t *testing.T) {
-	c := NewFrontendCompiler(&wasm.Module{}, ssa.NewBuilder(), nil, false, false, false)
+	c := NewFrontendCompiler(&wasm.Module{}, ssa.NewBuilder(), nil, false, false, false, false)
 	blk := c.ssaBuilder.AllocateBasicBlock()
 	require.True(t, len(c.getKnownSafeBoundsAtTheEndOfBlocks(blk.ID()).View()) == 0)
 	c.ssaBuilder.SetCurrentBlock(blk)
@@ -3243,7 +3243,7 @@ func TestCompiler_finalizeKnownSafeBoundsAtTheEndOoBlock(t *testing.T) {
 
 func TestCompiler_initializeCurrentBlockKnownBounds(t *testing.T) {
 	t.Run("single (sealed)", func(t *testing.T) {
-		c := NewFrontendCompiler(&wasm.Module{}, ssa.NewBuilder(), nil, false, false, false)
+		c := NewFrontendCompiler(&wasm.Module{}, ssa.NewBuilder(), nil, false, false, false, false)
 		builder := c.ssaBuilder
 		child := builder.AllocateBasicBlock()
 		{
@@ -3274,7 +3274,7 @@ func TestCompiler_initializeCurrentBlockKnownBounds(t *testing.T) {
 		require.Equal(t, ssa.Value(54321), kb.absoluteAddr)
 	})
 	t.Run("single (unsealed)", func(t *testing.T) {
-		c := NewFrontendCompiler(&wasm.Module{}, ssa.NewBuilder(), nil, false, false, false)
+		c := NewFrontendCompiler(&wasm.Module{}, ssa.NewBuilder(), nil, false, false, false, false)
 		builder := c.ssaBuilder
 		child := builder.AllocateBasicBlock()
 		{
@@ -3304,7 +3304,7 @@ func TestCompiler_initializeCurrentBlockKnownBounds(t *testing.T) {
 		require.NotEqual(t, ssa.Value(54321), kb.absoluteAddr)
 	})
 	t.Run("multiple predecessors", func(t *testing.T) {
-		c := NewFrontendCompiler(&wasm.Module{}, ssa.NewBuilder(), nil, false, false, false)
+		c := NewFrontendCompiler(&wasm.Module{}, ssa.NewBuilder(), nil, false, false, false, false)
 		builder := c.ssaBuilder
 		child := builder.AllocateBasicBlock()
 		{

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -1314,6 +1314,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 			panic("BUG")
 		}
 		builder.InsertInstruction(load)
+		c.markGuestMemoryLoad(load)
 		state.push(load.Return())
 	case wasm.OpcodeBlock:
 		// Note: we do not need to create a BB for this as that would always have only one predecessor
@@ -1701,6 +1702,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 			load := builder.AllocateInstruction()
 			load.AsLoad(addr, offset, ssa.TypeV128)
 			builder.InsertInstruction(load)
+			c.markGuestMemoryLoad(load)
 			state.push(load.Return())
 		case wasm.OpcodeVecV128Load8Lane, wasm.OpcodeVecV128Load16Lane, wasm.OpcodeVecV128Load32Lane:
 			_, offset := c.readMemArg()
@@ -1723,9 +1725,11 @@ func (c *Compiler) lowerCurrentOpcode() {
 			vector := state.pop()
 			baseAddr := state.pop()
 			addr := c.memOpSetup(baseAddr, uint64(offset), opSize)
-			load := builder.AllocateInstruction().
+			loadInstr := builder.AllocateInstruction().
 				AsExtLoad(loadOp, addr, offset, false).
-				Insert(builder).Return()
+				Insert(builder)
+			c.markGuestMemoryLoad(loadInstr)
+			load := loadInstr.Return()
 			ret := builder.AllocateInstruction().
 				AsInsertlane(vector, load, laneIndex, lane).
 				Insert(builder).Return()
@@ -1740,9 +1744,11 @@ func (c *Compiler) lowerCurrentOpcode() {
 			vector := state.pop()
 			baseAddr := state.pop()
 			addr := c.memOpSetup(baseAddr, uint64(offset), 8)
-			load := builder.AllocateInstruction().
+			loadInstr := builder.AllocateInstruction().
 				AsLoad(addr, offset, ssa.TypeI64).
-				Insert(builder).Return()
+				Insert(builder)
+			c.markGuestMemoryLoad(loadInstr)
+			load := loadInstr.Return()
 			ret := builder.AllocateInstruction().
 				AsInsertlane(vector, load, laneIndex, ssa.VecLaneI64x2).
 				Insert(builder).Return()
@@ -1765,10 +1771,11 @@ func (c *Compiler) lowerCurrentOpcode() {
 			baseAddr := state.pop()
 			addr := c.memOpSetup(baseAddr, uint64(offset), uint64(scalarType.Size()))
 
-			ret := builder.AllocateInstruction().
+			loadInstr := builder.AllocateInstruction().
 				AsVZeroExtLoad(addr, offset, scalarType).
-				Insert(builder).Return()
-			state.push(ret)
+				Insert(builder)
+			c.markGuestMemoryLoad(loadInstr)
+			state.push(loadInstr.Return())
 
 		case wasm.OpcodeVecV128Load8x8u, wasm.OpcodeVecV128Load8x8s,
 			wasm.OpcodeVecV128Load16x4u, wasm.OpcodeVecV128Load16x4s,
@@ -1798,9 +1805,11 @@ func (c *Compiler) lowerCurrentOpcode() {
 			}
 			baseAddr := state.pop()
 			addr := c.memOpSetup(baseAddr, uint64(offset), 8)
-			load := builder.AllocateInstruction().
+			loadInstr := builder.AllocateInstruction().
 				AsLoad(addr, offset, ssa.TypeF64).
-				Insert(builder).Return()
+				Insert(builder)
+			c.markGuestMemoryLoad(loadInstr)
+			load := loadInstr.Return()
 			ret := builder.AllocateInstruction().
 				AsWiden(load, lane, signed, true).
 				Insert(builder).Return()
@@ -1825,10 +1834,11 @@ func (c *Compiler) lowerCurrentOpcode() {
 			}
 			baseAddr := state.pop()
 			addr := c.memOpSetup(baseAddr, uint64(offset), opSize)
-			ret := builder.AllocateInstruction().
+			loadInstr := builder.AllocateInstruction().
 				AsLoadSplat(addr, offset, lane).
-				Insert(builder).Return()
-			state.push(ret)
+				Insert(builder)
+			c.markGuestMemoryLoad(loadInstr)
+			state.push(loadInstr.Return())
 		case wasm.OpcodeVecV128Store:
 			_, offset := c.readMemArg()
 			if state.unreachable {
@@ -4261,6 +4271,29 @@ func (c *Compiler) memOpSetup(baseAddr ssa.Value, constOffset, operationSizeInBy
 	address = ssa.ValueInvalid
 	builder := c.ssaBuilder
 
+	// With guard-page backed memory, any u32 base + u32 static offset +
+	// access size lands inside the reserved (and partially inaccessible)
+	// region, so an out-of-bounds access faults in hardware instead of
+	// requiring an explicit check; the fault is translated back to the
+	// regular out-of-bounds trap by the call engine.
+	if c.memoryGuarded {
+		baseAddrID := baseAddr.ID()
+		if known := c.getKnownSafeBound(baseAddrID); known.valid() && known.absoluteAddr.Valid() {
+			return known.absoluteAddr
+		}
+		memBase := c.getMemoryBaseValue(false)
+		extBaseAddr := builder.AllocateInstruction().
+			AsUExtend(baseAddr, 32, 64).
+			Insert(builder).
+			Return()
+		address = builder.AllocateInstruction().
+			AsIadd(memBase, extBaseAddr).Insert(builder).Return()
+		// Record the computed absolute address so subsequent accesses on the
+		// same base value in this block reuse it.
+		c.recordKnownSafeBound(baseAddrID, 1<<62, address)
+		return
+	}
+
 	baseAddrID := baseAddr.ID()
 	ceil := constOffset + operationSizeInBytes
 	if known := c.getKnownSafeBound(baseAddrID); known.valid() {
@@ -5150,4 +5183,14 @@ func (c *Compiler) boundsCheckInMemory(memLen, offset, size ssa.Value) {
 	builder.AllocateInstruction().
 		AsExitIfTrueWithCode(c.execCtxPtrValue, cmp, wazevoapi.ExitCodeMemoryOutOfBounds).
 		Insert(builder)
+}
+
+// markGuestMemoryLoad marks a guest linear-memory load as trapping when the
+// memory is guard-page backed and bounds checks are omitted: the access
+// itself then carries the wasm out-of-bounds trap semantics and must not be
+// dead-code-eliminated even if its result is unused.
+func (c *Compiler) markGuestMemoryLoad(load *ssa.Instruction) {
+	if c.memoryGuarded {
+		load.MarkAsTrapping()
+	}
 }

--- a/internal/engine/wazevo/module_engine.go
+++ b/internal/engine/wazevo/module_engine.go
@@ -263,6 +263,14 @@ func (m *moduleEngine) putLocalMemory() {
 	var b uint64
 	if len(mem.Buffer) > 0 {
 		b = uint64(uintptr(unsafe.Pointer(&mem.Buffer[0])))
+	} else if mem.GuardBacked {
+		// A guard-backed memory must publish its (stable) reservation base
+		// even when the memory is currently empty: without bounds checks the
+		// generated code dereferences base+addr directly, and the fault
+		// address must land inside the guard region to be recognized as a
+		// guest out-of-bounds access. The buffer always aliases the
+		// reservation, so its data pointer is the base even at length zero.
+		b = uint64(uintptr(unsafe.Pointer(unsafe.SliceData(mem.Buffer))))
 	}
 	binary.LittleEndian.PutUint64(m.opaque[offset:], b)
 	binary.LittleEndian.PutUint64(m.opaque[offset+8:], s)

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -37,6 +37,9 @@ type Instruction struct {
 	sourceOffset   SourceOffset
 	live           bool
 	alreadyLowered bool
+	// trapping overrides the opcode's static side-effect classification to
+	// sideEffectTraps. See MarkAsTrapping.
+	trapping bool
 }
 
 // SourceOffset represents the offset of the source of an instruction.
@@ -893,11 +896,25 @@ var instructionSideEffects = [opcodeEnd]sideEffect{
 
 // sideEffect returns true if this instruction has side effects.
 func (i *Instruction) sideEffect() sideEffect {
+	if i.trapping {
+		return sideEffectTraps
+	}
 	if e := instructionSideEffects[i.opcode]; e == sideEffectUnknown {
 		panic("BUG: side effect info not registered for " + i.opcode.String())
 	} else {
 		return e
 	}
+}
+
+// MarkAsTrapping overrides this instruction's side-effect classification to
+// sideEffectTraps: the instruction stays alive even if its result is unused,
+// but may still be reordered within its instruction group. This is used for
+// memory accesses compiled without explicit bounds checks (guard-page backed
+// memory), where the hardware fault raised by the access itself implements
+// the wasm out-of-bounds trap and the access therefore must not be
+// dead-code-eliminated.
+func (i *Instruction) MarkAsTrapping() {
+	i.trapping = true
 }
 
 // instructionReturnTypes provides the function to determine the return types of an instruction.

--- a/internal/expctxkeys/guardmemory.go
+++ b/internal/expctxkeys/guardmemory.go
@@ -1,0 +1,6 @@
+package expctxkeys
+
+// GuardPageMemoryKey is a context.Context Value key. Its value must be true
+// to enable guard-page-backed linear memory, which lets the compiler omit
+// per-access memory bounds checks. See experimental.WithGuardPageMemory.
+type GuardPageMemoryKey struct{}

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -8,8 +8,12 @@ import (
 	"runtime"
 	"testing"
 
+	"os"
+
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
+	_ "github.com/tetratelabs/wazero/experimental/guardsig"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/internal/platform"
 )
@@ -17,7 +21,13 @@ import (
 type arbitrary struct{}
 
 // testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
-var testCtx = context.WithValue(context.Background(), arbitrary{}, "arbitrary")
+var testCtx = func() context.Context {
+	ctx := context.WithValue(context.Background(), arbitrary{}, "arbitrary")
+	if os.Getenv("WAZERO_GUARD_MEMORY") == "1" {
+		ctx = experimental.WithGuardPageMemory(ctx)
+	}
+	return ctx
+}()
 
 // caseWasm was compiled from TinyGo testdata/case.go
 //

--- a/internal/integration_test/spectest/v2/spec_test.go
+++ b/internal/integration_test/spectest/v2/spec_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/experimental/guardsig"
 	"github.com/tetratelabs/wazero/internal/integration_test/spectest"
 	"github.com/tetratelabs/wazero/internal/platform"
 )
@@ -21,4 +23,17 @@ func TestCompiler(t *testing.T) {
 
 func TestInterpreter(t *testing.T) {
 	spectest.Run(t, Testcases, context.Background(), wazero.NewRuntimeConfigInterpreter().WithCoreFeatures(enabledFeatures))
+}
+
+// TestCompilerGuardPageMemory runs the whole suite with guard-page backed
+// linear memory (no per-access bounds checks in the generated code); every
+// out-of-bounds trap assertion must still hold, now via the hardware fault
+// path (the guardsig signal handler redirecting the faulting thread to the
+// guard-fault exit sequence).
+func TestCompilerGuardPageMemory(t *testing.T) {
+	if !platform.CompilerSupported() || !platform.GuardPageMemorySupported || !guardsig.Supported() {
+		t.Skip()
+	}
+	ctx := experimental.WithGuardPageMemory(context.Background())
+	spectest.Run(t, Testcases, ctx, wazero.NewRuntimeConfigCompiler().WithCoreFeatures(enabledFeatures))
 }

--- a/internal/integration_test/stdlibs/bench_test.go
+++ b/internal/integration_test/stdlibs/bench_test.go
@@ -13,14 +13,24 @@ import (
 	"testing"
 
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/experimental"
+	_ "github.com/tetratelabs/wazero/experimental/guardsig"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/sys"
 )
 
+func benchCtx() context.Context {
+	ctx := context.Background()
+	if os.Getenv("WAZERO_GUARD_MEMORY") == "1" {
+		ctx = experimental.WithGuardPageMemory(ctx)
+	}
+	return ctx
+}
+
 func BenchmarkZig(b *testing.B) {
 	c := wazero.NewRuntimeConfigCompiler()
-	runtBenches(b, context.Background(), c, zigTestCase)
+	runtBenches(b, benchCtx(), c, zigTestCase)
 }
 
 func BenchmarkWasip1(b *testing.B) {

--- a/internal/platform/guard_memory.go
+++ b/internal/platform/guard_memory.go
@@ -1,0 +1,69 @@
+package platform
+
+import (
+	"sort"
+	"sync"
+)
+
+// GuardRegionReserveSize is the virtual reservation for one guard-page
+// backed 32-bit linear memory: the whole 4 GiB wasm address space, plus
+// another 4 GiB so that any u32 base + u32 static offset + access size lands
+// inside the reservation, plus a 64 KiB tail so the largest access starting
+// at the very end still faults inside the region.
+const GuardRegionReserveSize = 1<<33 + 1<<16
+
+// guardRegions tracks the [base, end) address ranges of live guard-page
+// backed memories so that a caught hardware fault can be classified: faults
+// inside a registered region are guest out-of-bounds accesses; everything
+// else is a genuine runtime error and must not be masked.
+var guardRegions struct {
+	mu      sync.RWMutex
+	regions []guardRegion // sorted by base
+}
+
+type guardRegion struct{ base, end uintptr }
+
+// RegisterGuardRegion records a reserved region so faults inside it can be
+// recognized as guest out-of-bounds accesses, both by the Go-side fault
+// translation (recovered panics from Go code under SetPanicOnFault) and by
+// the optional signal handler (faults from JIT code). Returns false if the
+// signal handler's registry is full, in which case the region must not be
+// used as a guard-page memory.
+func RegisterGuardRegion(base, end uintptr) bool {
+	if !guardSigRegionAdd(base, end) {
+		return false
+	}
+	guardRegions.mu.Lock()
+	defer guardRegions.mu.Unlock()
+	i := sort.Search(len(guardRegions.regions), func(i int) bool {
+		return guardRegions.regions[i].base >= base
+	})
+	guardRegions.regions = append(guardRegions.regions, guardRegion{})
+	copy(guardRegions.regions[i+1:], guardRegions.regions[i:])
+	guardRegions.regions[i] = guardRegion{base: base, end: end}
+	return true
+}
+
+// UnregisterGuardRegion removes a previously registered region.
+func UnregisterGuardRegion(base uintptr) {
+	guardSigRegionDel(base)
+	guardRegions.mu.Lock()
+	defer guardRegions.mu.Unlock()
+	for i, r := range guardRegions.regions {
+		if r.base == base {
+			guardRegions.regions = append(guardRegions.regions[:i], guardRegions.regions[i+1:]...)
+			return
+		}
+	}
+}
+
+// IsGuardRegionAddr returns true if addr falls inside a registered guard
+// region. Only called on the (error) fault path.
+func IsGuardRegionAddr(addr uintptr) bool {
+	guardRegions.mu.RLock()
+	defer guardRegions.mu.RUnlock()
+	i := sort.Search(len(guardRegions.regions), func(i int) bool {
+		return guardRegions.regions[i].end > addr
+	})
+	return i < len(guardRegions.regions) && guardRegions.regions[i].base <= addr
+}

--- a/internal/platform/guard_memory_unix.go
+++ b/internal/platform/guard_memory_unix.go
@@ -1,0 +1,33 @@
+//go:build (darwin || linux || freebsd) && (amd64 || arm64)
+
+package platform
+
+import "syscall"
+
+// GuardPageMemorySupported is true when guard-page-backed linear memory is
+// available: a 64-bit unix-like platform where a large PROT_NONE
+// reservation is cheap and faults surface as recoverable Go panics under
+// runtime/debug.SetPanicOnFault.
+const GuardPageMemorySupported = true
+
+// ReserveGuardRegion reserves size bytes of inaccessible (PROT_NONE)
+// address space. Nothing is committed; the reservation only consumes
+// virtual address space.
+func ReserveGuardRegion(size uintptr) ([]byte, error) {
+	return syscall.Mmap(-1, 0, int(size), syscall.PROT_NONE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE)
+}
+
+// CommitGuardRegion makes the first commitBytes of the reservation
+// readable and writable.
+func CommitGuardRegion(region []byte, commitBytes uintptr) error {
+	if commitBytes == 0 {
+		return nil
+	}
+	return syscall.Mprotect(region[:commitBytes], syscall.PROT_READ|syscall.PROT_WRITE)
+}
+
+// ReleaseGuardRegion releases the whole reservation.
+func ReleaseGuardRegion(region []byte) error {
+	return syscall.Munmap(region)
+}

--- a/internal/platform/guard_memory_unsupported.go
+++ b/internal/platform/guard_memory_unsupported.go
@@ -1,0 +1,15 @@
+//go:build !((darwin || linux || freebsd) && (amd64 || arm64))
+
+package platform
+
+import "errors"
+
+// GuardPageMemorySupported is false on this platform; guard-page-backed
+// linear memory silently falls back to bounds-checked code generation.
+const GuardPageMemorySupported = false
+
+var errGuardUnsupported = errors.New("guard-page memory is not supported on this platform")
+
+func ReserveGuardRegion(uintptr) ([]byte, error) { return nil, errGuardUnsupported }
+func CommitGuardRegion([]byte, uintptr) error    { return errGuardUnsupported }
+func ReleaseGuardRegion([]byte) error            { return errGuardUnsupported }

--- a/internal/platform/guard_signal.go
+++ b/internal/platform/guard_signal.go
@@ -1,0 +1,80 @@
+package platform
+
+// Guard-page-backed memories need a way to turn a hardware fault raised by
+// wazevo-generated code into a regular wasm out-of-bounds trap. The Go
+// runtime cannot recover faults at non-Go (JIT) program counters, so that
+// translation is done by an optional, cgo-based signal handler that lives in
+// the separate experimental/guardsig package. That package injects its
+// registration functions here at init; when it is not linked in (or cgo is
+// disabled), the hooks stay nil and the engine keeps generating explicit
+// bounds checks even when guard-page memory is requested.
+var guardFaultHooks struct {
+	// installed reports whether the fault handler was successfully
+	// installed before the Go runtime started.
+	installed func() bool
+	// regionAdd/regionDel mirror the Go-side guard-region registry into the
+	// handler's async-signal-safe registry. regionAdd reports whether the
+	// registration succeeded (the handler's table is fixed-size).
+	regionAdd func(base, end uintptr) bool
+	regionDel func(base uintptr)
+	// stackAdd/stackDel register the [lo, hi) range of a call engine's
+	// stack together with the execution context pointer and the address of
+	// the compiled guard-fault exit sequence for that engine, so the
+	// handler can redirect a faulting thread. stackAdd reports whether the
+	// registration succeeded.
+	stackAdd func(lo, hi, execCtx, exitSeq uintptr) bool
+	stackDel func(lo uintptr)
+}
+
+// SetGuardFaultHandlerHooks is called (at most once, from an init function)
+// by the experimental/guardsig package to make its signal handler available
+// to the engine. It must not be called after any engine has been created.
+func SetGuardFaultHandlerHooks(
+	installed func() bool,
+	regionAdd func(base, end uintptr) bool,
+	regionDel func(base uintptr),
+	stackAdd func(lo, hi, execCtx, exitSeq uintptr) bool,
+	stackDel func(lo uintptr),
+) {
+	guardFaultHooks.installed = installed
+	guardFaultHooks.regionAdd = regionAdd
+	guardFaultHooks.regionDel = regionDel
+	guardFaultHooks.stackAdd = stackAdd
+	guardFaultHooks.stackDel = stackDel
+}
+
+// GuardFaultHandlerInstalled returns true when the guard-fault signal
+// handler is linked in and active, which is a precondition for generating
+// code without per-access memory bounds checks.
+func GuardFaultHandlerInstalled() bool {
+	return guardFaultHooks.installed != nil && guardFaultHooks.installed()
+}
+
+// GuardSigStackAdd registers a call engine stack with the fault handler.
+// Returns true on success, or when no handler is present (nothing to do).
+func GuardSigStackAdd(lo, hi, execCtx, exitSeq uintptr) bool {
+	if guardFaultHooks.stackAdd == nil {
+		return true
+	}
+	return guardFaultHooks.stackAdd(lo, hi, execCtx, exitSeq)
+}
+
+// GuardSigStackDel removes a previously registered call engine stack.
+func GuardSigStackDel(lo uintptr) {
+	if guardFaultHooks.stackDel != nil {
+		guardFaultHooks.stackDel(lo)
+	}
+}
+
+func guardSigRegionAdd(base, end uintptr) bool {
+	if guardFaultHooks.regionAdd == nil {
+		return true
+	}
+	return guardFaultHooks.regionAdd(base, end)
+}
+
+func guardSigRegionDel(base uintptr) {
+	if guardFaultHooks.regionDel != nil {
+		guardFaultHooks.regionDel(base)
+	}
+}

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/internal/internalapi"
+	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/wasmruntime"
 )
 
@@ -64,21 +65,37 @@ type MemoryInstance struct {
 	ownerModuleEngine ModuleEngine
 
 	expBuffer experimental.LinearMemory
+
+	// GuardBacked is true when the memory is backed by a guard-page
+	// reservation (see experimental.WithGuardPageMemory), which allows the
+	// compiler to omit per-access bounds checks.
+	GuardBacked bool
 }
 
 // NewMemoryInstance creates a new instance based on the parameters in the SectionIDMemory.
-func NewMemoryInstance(memSec *Memory, allocator experimental.MemoryAllocator, moduleEngine ModuleEngine) *MemoryInstance {
+func NewMemoryInstance(memSec *Memory, allocator experimental.MemoryAllocator, guarded bool, moduleEngine ModuleEngine) *MemoryInstance {
 	minBytes := MemoryPagesToBytesNum(memSec.Min)
 	capBytes := MemoryPagesToBytesNum(memSec.Cap)
 	maxBytes := MemoryPagesToBytesNum(memSec.Max)
 
 	var buffer []byte
 	var expBuffer experimental.LinearMemory
-	if allocator != nil {
+	var guardBacked bool
+	if guarded && platform.GuardPageMemorySupported && !memSec.IsShared && allocator == nil {
+		if g, err := newGuardedLinearMemory(maxBytes); err == nil {
+			expBuffer = g
+			buffer = expBuffer.Reallocate(minBytes)
+			_ = buffer[:minBytes] // Bounds check that the minimum was allocated.
+			guardBacked = true
+		}
+		// On reservation failure, fall through to the regular allocation
+		// below (the engine will refuse to pair it with checkless code).
+	}
+	if buffer == nil && !guardBacked && allocator != nil {
 		expBuffer = allocator.Allocate(capBytes, maxBytes)
 		buffer = expBuffer.Reallocate(minBytes)
 		_ = buffer[:minBytes] // Bounds check that the minimum was allocated.
-	} else if memSec.IsShared {
+	} else if buffer == nil && memSec.IsShared {
 		// Shared memory needs a fixed buffer, so allocate with the maximum size.
 		//
 		// The rationale as to why we can simply use make([]byte) to a fixed buffer is that Go's GC is non-relocating.
@@ -89,10 +106,11 @@ func NewMemoryInstance(memSec *Memory, allocator experimental.MemoryAllocator, m
 		// the memory buffer allocation here is virtual and doesn't consume physical memory until it's used.
 		// 	* https://github.com/golang/go/blob/go1.24.0/src/runtime/malloc.go#L1059
 		buffer = make([]byte, minBytes, maxBytes)
-	} else {
+	} else if buffer == nil {
 		buffer = make([]byte, minBytes, capBytes)
 	}
 	return &MemoryInstance{
+		GuardBacked:       guardBacked,
 		Buffer:            buffer,
 		Min:               memSec.Min,
 		Cap:               memoryBytesNumToPages(uint64(cap(buffer))),

--- a/internal/wasm/memory_guard.go
+++ b/internal/wasm/memory_guard.go
@@ -1,0 +1,64 @@
+package wasm
+
+import (
+	"errors"
+	"os"
+	"unsafe"
+
+	"github.com/tetratelabs/wazero/internal/platform"
+)
+
+// guardedLinearMemory is a LinearMemory backed by a large PROT_NONE virtual
+// reservation whose committed prefix grows via mprotect. The base address is
+// stable for the lifetime of the memory, and any out-of-bounds access up to
+// the guard window faults instead of reading/writing unrelated data, which
+// is what allows the compiler to omit per-access bounds checks.
+type guardedLinearMemory struct {
+	region    []byte // the whole reservation
+	max       uint64
+	committed uintptr
+}
+
+func newGuardedLinearMemory(maxBytes uint64) (*guardedLinearMemory, error) {
+	region, err := platform.ReserveGuardRegion(platform.GuardRegionReserveSize)
+	if err != nil {
+		return nil, err
+	}
+	base := uintptr(unsafe.Pointer(&region[0]))
+	if !platform.RegisterGuardRegion(base, base+platform.GuardRegionReserveSize) {
+		_ = platform.ReleaseGuardRegion(region)
+		return nil, errors.New("wazero: guard-region registry is full")
+	}
+	return &guardedLinearMemory{region: region, max: maxBytes}, nil
+}
+
+// Reallocate implements experimental.LinearMemory.
+func (g *guardedLinearMemory) Reallocate(size uint64) []byte {
+	if size > g.max || size > uint64(len(g.region)) {
+		return nil
+	}
+	pageSize := uintptr(os.Getpagesize())
+	aligned := (uintptr(size) + pageSize - 1) &^ (pageSize - 1)
+	if aligned > g.committed {
+		if err := platform.CommitGuardRegion(g.region, aligned); err != nil {
+			return nil
+		}
+		g.committed = aligned
+	}
+	if size == 0 {
+		// Keep a non-zero capacity so the returned slice's data pointer
+		// (the reservation base) stays well-defined for unsafe.SliceData.
+		return g.region[:0:1]
+	}
+	return g.region[:size:size]
+}
+
+// Free implements experimental.LinearMemory.
+func (g *guardedLinearMemory) Free() {
+	if g.region == nil {
+		return
+	}
+	platform.UnregisterGuardRegion(uintptr(unsafe.Pointer(&g.region[0])))
+	_ = platform.ReleaseGuardRegion(g.region)
+	g.region = nil
+}

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -867,7 +867,7 @@ func TestNewMemoryInstance_Shared(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			m := NewMemoryInstance(tc.mem, nil, me)
+			m := NewMemoryInstance(tc.mem, nil, false, me)
 			require.Equal(t, tc.mem.Min, m.Min)
 			require.Equal(t, tc.mem.Max, m.Max)
 			require.Equal(t, me, m.ownerModuleEngine)

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -775,10 +775,10 @@ func paramNames(localNames IndirectNameMap, funcIdx uint32, paramLen int) []stri
 	return nil
 }
 
-func (m *ModuleInstance) buildMemory(module *Module, allocator experimental.MemoryAllocator) {
+func (m *ModuleInstance) buildMemory(module *Module, allocator experimental.MemoryAllocator, guarded bool) {
 	memSec := module.MemorySection
 	if memSec != nil {
-		m.MemoryInstance = NewMemoryInstance(memSec, allocator, m.Engine)
+		m.MemoryInstance = NewMemoryInstance(memSec, allocator, guarded, m.Engine)
 		m.MemoryInstance.definition = &module.MemoryDefinitionSection[0]
 	}
 }

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -852,7 +852,7 @@ func TestModule_buildGlobals(t *testing.T) {
 func TestModule_buildMemoryInstance(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		m := ModuleInstance{}
-		m.buildMemory(&Module{}, nil)
+		m.buildMemory(&Module{}, nil, false)
 		require.Nil(t, m.MemoryInstance)
 	})
 	t.Run("non-nil", func(t *testing.T) {
@@ -863,7 +863,7 @@ func TestModule_buildMemoryInstance(t *testing.T) {
 		m.buildMemory(&Module{
 			MemorySection:           &Memory{Min: min, Cap: min, Max: max},
 			MemoryDefinitionSection: []MemoryDefinition{mDef},
-		}, nil)
+		}, nil, false)
 		mem := m.MemoryInstance
 		require.Equal(t, min, mem.Min)
 		require.Equal(t, max, mem.Max)

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -367,10 +367,11 @@ func (s *Store) instantiate(
 	}
 
 	allocator, _ := ctx.Value(expctxkeys.MemoryAllocatorKey{}).(experimental.MemoryAllocator)
+	guardedMemory, _ := ctx.Value(expctxkeys.GuardPageMemoryKey{}).(bool)
 
 	m.buildGlobals(module, m.Engine.FunctionInstanceReference)
 	m.buildTags(module)
-	m.buildMemory(module, allocator)
+	m.buildMemory(module, allocator, guardedMemory)
 	m.Exports = module.Exports
 	for _, exp := range m.Exports {
 		if exp.Type == ExternTypeTable {


### PR DESCRIPTION
## Design

### Problem

Per-access memory bounds checks are the single largest overhead wazevo adds to memory-intensive workloads. Every guest load/store compiles to a compare+branch against the memory length before the access — and on dynamic `base + induction` addresses inside hot loops (the shape image decoders and rasterizers produce), no SSA-level elision can remove them: each iteration's address is a fresh value. A diagnostic no-bounds-checks build measured **−22% geomean** on a PDF-rendering corpus.

Every hardware-fault-based wasm runtime (wasmtime, V8, JSC) solves this with virtual memory: reserve inaccessible address space so large that *any* `u32 base + u32 static offset + access size` computed by guest code lands inside it, commit only the actual memory, and let out-of-bounds accesses fault. The trap becomes free until it actually happens.

### What this PR adds

**1. Guard-page memories** (`experimental.WithGuardPageMemory(ctx)`, pure Go): each linear memory is an **8 GiB + 64 KiB `PROT_NONE` reservation** (4 GiB max wasm memory + 4 GiB max static offset + max access size), with the committed prefix grown by `mprotect` on `memory.grow`. The base address is stable for the memory's lifetime. Supported on unix-like 64-bit platforms; anywhere else the context flag is silently ignored.

**2. Checkless code generation** (wazevo): in guarded mode, `memOpSetup` emits no bounds check for plain loads/stores — just `memBase + zext(addr)` (with block-local reuse of the computed absolute address). Bulk operations (`memory.copy`/`fill`/`init`) keep their explicit length checks, because they execute via `runtime.memmove` — Go code that must never touch the guard region.

**3. The fault-to-trap translation** (`experimental/guardsig`, cgo, opt-in by blank import): the Go runtime cannot recover a fault raised at a JIT program counter — `debug.SetPanicOnFault` only covers faults at Go PCs, and a guest OOB access faults inside wazevo-generated code, killing the process with `fatal error: unknown caller pc`. The guardsig package installs a C signal handler for SIGSEGV/SIGBUS that:

- checks the fault address against a registry of live guard regions, and the faulting thread's stack pointer against a registry of live wasm call stacks (which yields the execution context — wasm always runs on wazero-allocated stacks, and Go host code never does, so the SP test cleanly separates "guest access" from everything else);
- if both match, rewrites the signal context: execution-context pointer and faulting PC into two registers (arm64: x0/x1, amd64: rax/rcx), PC to a per-engine compiled **guard-fault exit sequence**, and resumes. That sequence is 7 instructions doing exactly what an inline trap exit does — store `ExitCodeMemoryOutOfBounds`, store SP for stack unwinding, store the faulting PC for source mapping, and run the standard exit sequence back to Go — so the embedder sees the identical `ErrRuntimeOutOfBoundsMemoryAccess`, with a correct wasm stack trace, that a bounds check would have produced;
- otherwise chains to the Go runtime's own handler, saved at install time. Crashes that are not guest OOB accesses (including wild pointers in Go code that happen to hit a guard region — the SP test excludes them) behave exactly as without this package, Go crash dump included.

**A finding worth recording for reviewers:** the "have Go forward signals to a pre-existing C handler" direction — a constructor-installed handler, which the earlier design sketch assumed — **does not work for JIT code**. The runtime only forwards synchronous signals raised on non-Go threads or inside cgo calls (`sigfwdgo` checks `m.curg`/`incgo`); JIT code running on an ordinary goroutine fails that test, and the runtime fatals before consulting the C handler. The working direction is the opposite, also documented in os/signal: install *after* runtime init, becoming the primary handler, and chain to the saved Go handler for everything not ours. This also preserves Go's crash reporting for unrelated faults, which the forwarding direction would not have.

**4. Safety interlocks:**
- Checkless compilation only happens when the ctx flag is set **and** the platform supports reservations **and** the guardsig handler is installed. Without any of the three, the same program compiles with bounds checks and behaves identically — wazero itself stays a pure-Go module.
- A module compiled checkless **refuses to instantiate** against a memory that is not guard-backed (and the file-cache key separates guarded artifacts), so no checkless code can ever run against a plain heap buffer.
- Because the trap is now a side effect of the access itself, guest loads are marked non-eliminable in guarded mode (`ssa.Instruction.MarkAsTrapping`): a load whose result is unused must still trap, as the spec requires (`(drop (i32.load ...))` — the `no_dce.*` and `*_bad` spec tests).
- Empty memories (`(memory 0)`) publish the reservation base — not a nil pointer — as the module's memory base, so their OOB accesses still fault inside the region.
- Registries are async-signal-safe **and cgo-free on the registration path**: the tables live in C static memory, but Go writes them directly (plain field stores, then the key field with an atomic release store; the handler reads the key with acquire semantics). This matters: an earlier version did a cgo call per registration, and since a call engine registers its stack at creation, embedders that call `mod.ExportedFunction(...)` per invocation — a very common pattern — paid a cgo call per wasm call, which showed up as a +36% regression on one benchmark. With direct writes the same benchmark improves 13% instead. Call-engine stacks re-register on growth/replacement and deregister via finalizer.

### Scope and limitations

- Requires cgo **only for programs that opt in** by importing `experimental/guardsig`; nothing changes for anyone else. `CGO_ENABLED=0` builds of a program importing it compile fine and fall back to checked codegen (`guardsig.Supported()` reports which mode you got).
- Platforms: darwin/linux on amd64/arm64 for the handler (freebsd has the reservation support; its sigcontext accessors are a follow-up). Windows would need vectored exception handling — out of scope.
- Shared (threads) memories fall back to checked codegen.
- Address space, not physical memory: 8 GiB of reservation per memory instance. Fine on 64-bit; the reason there is no 32-bit support.
- Programs that install their own SIGSEGV handler *after* guardsig's init would displace it; standard interposition caveat, documented on the package.

## Correctness

- **The full spectest v2 suite runs and passes under guard mode** (`TestCompilerGuardPageMemory`) — including every out-of-bounds trap assertion, now exercised through the hardware fault path — on darwin/arm64 and darwin/amd64 (Rosetta).
- The regular test matrix (all spectest suites, wazevo unit tests, engine integration, `-race`) passes unchanged with guard mode off; `CGO_ENABLED=0`, windows, and riscv64 builds verified.
- New `experimental/guardsig` test: in/out-of-bounds probes at the boundary, dropped-result loads, traps after `memory.grow` moves the boundary, engine reuse after repeated traps.
- A downstream golden-hash corpus (PDFium-as-wasm rendering 32 verified outputs, plus the EH corpus) is **pixel-identical** under guard mode.

## Measured performance (Apple M5, arm64; benchstat n=6, interleaved; base = main @ ab01134c)

> Note: measured with normal desktop background load (Docker Desktop VM idle, Spotify); the three legs were interleaved per pass so steady load cancels out of the comparisons.

### PDF rendering (go-pdfium: PDFium-as-wasm, open + render at 200 DPI + close)

Geomean **−21.9%** — matching the −22.2% the no-bounds-checks diagnostic build predicted, i.e. the mechanism recovers the entire bounds-check cost:

```
                          main          guard on
rect-heavy PNG document   28.93m ± 17%  22.77m ±  4%  -21.31% (p=0.002)
alpha-compositing doc     90.94m ±  3%  75.37m ±  1%  -17.13% (p=0.002)
test.pdf                  1.363m ±  7%  1.188m ±  8%  -12.82% (p=0.002)
building plan             3.159m ±  8%  2.764m ±  8%  -12.52% (p=0.002)
invoice A                 9.659m ±  5%  7.678m ± 11%  -20.51% (p=0.002)
scanned-image document   102.47m ±  5%  64.85m ±  2%  -36.71% (p=0.002)
invoice B                 6.143m ±  3%  4.792m ± 87%       ~  (p=0.065)
photo document (mona)     554.5µ ±  4%  392.2µ ±  9%  -29.27% (p=0.002)
geomean                   8.866m        6.922m        -21.92%
```

(The invoice B row caught a background-load spike — ±87% — and is not significant; its median moved in line with the rest.)

Against the fully-patched native library measured earlier on the same corpus, this takes the wasm runtime from **~2.04× to ~1.6× native** — most of the way to the 1.5× target in one change.

### Overhead when disabled (branch with guard off vs main)

None: every row not significant (all p ≥ 0.18), geomean +0.9% which is within the run-to-run noise of this corpus. The disabled path adds only nil-checks on function-pointer hooks.

### wazero's own benchmark suite (`BenchmarkInvocation/compiler`)

Geomean **−13.9%**, no significant regressions:

```
base64_5_per_exec         6.972µ →  6.056µ   -13.15% (p=0.002)
base64_100_per_exec       140.9µ →  120.6µ   -14.41% (p=0.002)
base64_10000_per_exec     13.98m →  12.10m   -13.49% (p=0.002)
string_manipulation_100   23.48µ →  18.42µ   -21.55% (p=0.002)
string_manipulation_1000  1.657m →  1.494m    -9.83% (p=0.002)
reverse_array_500         1.614µ →  1.366µ   -15.37% (p=0.002)
random_mat_mul_10        10.737µ →  7.490µ   -30.24% (p=0.002)
random_mat_mul_20         48.10µ →  28.39µ   -40.97% (p=0.002)
fib_for_5..30                  (all ~, p>0.39: pure compute, few memory accesses)
geomean                   20.13µ →  17.33µ   -13.89%
```

### Zig stdlib suite (`internal/integration_test/stdlibs`, Zig 0.11.0)

Guard on, geomean **−18.8%** — and compilation itself gets faster too, because checkless codegen has far fewer instructions to lower:

```
Zig/Compile/test-opt.wasm   1.751 ± 2%   1.269 ± 2%  -27.55% (p=0.002)
Zig/Compile/test.wasm       2.070 ± 1%   1.629 ± 2%  -21.32% (p=0.002)
Zig/Run/test-opt.wasm      11.236 ± 1%   9.600 ± 0%  -14.56% (p=0.002)
Zig/Run/test.wasm           11.60 ± 1%   10.34 ± 0%  -10.84% (p=0.002)
geomean                     4.663        3.785       -18.82%
```

(The whole Zig stdlib test binary passing under guard mode is itself an extra correctness datapoint.)

Guard off: every row n.s., geomean +0.30%.

## Notes for review

- The cgo boundary is exactly one package; the core's knowledge of it is five function-pointer hooks in `internal/platform` (nil = feature off).
- The per-ISA knowledge added to the backends is one compiled sequence (`CompileGuardFaultExitSequence`), built from the same primitives as the existing exit sequences (`setExitCode`/`allocateExitInstructions` + `asExitSequence`).
- The register contract between the handler and the exit sequence (arm64 x0/x1, amd64 rax/rcx) is documented at both ends; the faulting PC is stored as `goCallReturnAddress` so wasm stack traces point at the faulting instruction, same as an inline check would.
- `MarkAsTrapping` is deliberately a per-instruction override rather than a change to the opcode side-effect table: only guest memory accesses in guarded modules need it; everything else keeps full DCE.
