### PR TITLE
Improve performance of WithCloseOnContextDone(true) 

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1519,20 +1519,6 @@ and as of Go 1.20, these assembler functions are considered as _unsafe_ for asyn
 From the Go runtime point of view, the execution of runtime-generated machine codes is considered as a part of
 that trampoline function. Therefore, runtime-generated machine code is also correctly considered unsafe for async preemption.
 
-## Why context cancellation is handled in Go code rather than native code
-
-Since [wazero v1.0.0-pre.9](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.9), the runtime
-supports integration with Go contexts to interrupt execution after a timeout, or in response to explicit cancellation.
-This support is internally implemented as a special opcode `builtinFunctionCheckExitCode` that triggers the execution of
-a Go function (`ModuleInstance.FailIfClosed`) that atomically checks a sentinel value at strategic points in the code.
-
-[It _is indeed_ possible to check the sentinel value directly, without leaving the native world][native_check], thus sparing some cycles;
-however, because native code never preempts (see section above), this may lead to a state where the other goroutines
-never get the chance to run, and thus never get the chance to set the sentinel value; effectively preventing
-cancellation from taking place.
-
-[native_check]: https://github.com/tetratelabs/wazero/issues/1409
-
 ## Golang patterns
 
 ### Hammer tests

--- a/internal/engine/interpreter/compiler.go
+++ b/internal/engine/interpreter/compiler.go
@@ -397,6 +397,14 @@ func (c *compiler) compile(sig *wasm.FunctionType, body []byte, localTypes []was
 		kind:      controlFrameKindFunction,
 	})
 
+	// A loop back-edge is not the only unbounded execution path: a loop-free call graph
+	// (f calls g twice, g calls h twice, ...) runs 2^depth calls at a fixed stack depth, and
+	// return_call self-recursion runs forever at a fixed depth too. Checking on entry closes
+	// both, and covers every call form since they all land here.
+	if c.ensureTermination {
+		c.emit(newOperationBuiltinFunctionCheckExitCode())
+	}
+
 	// Now, enter the function body.
 	for !c.controlFrames.empty() && c.pc < uint64(len(c.body)) {
 		if err := c.handleInstruction(); err != nil {

--- a/internal/engine/interpreter/compiler_test.go
+++ b/internal/engine/interpreter/compiler_test.go
@@ -3009,6 +3009,7 @@ func Test_ensureTermination(t *testing.T) {
 		{
 			ensureTermination: true,
 			exp: `.entrypoint
+	BuiltinFunctionCheckExitCode
 	ConstI32 0x0
 	Br .L2
 .L2

--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -49,6 +49,12 @@ type (
 		// pendingException holds the most recently caught exception, so handler
 		// code can read its params after re-entry.
 		pendingException *wasm.Exception
+
+		// entrypoint and afterGoFunctionCallEntrypoint are how this call enters compiled
+		// code. Which pair they hold depends on whether the module was compiled with
+		// ensureTermination: see entrypoints.
+		entrypoint                    entrypointFn
+		afterGoFunctionCallEntrypoint afterGoFunctionCallEntrypointFn
 	}
 
 	// tryHandler records the state at a try_table entry for exception handling.
@@ -147,6 +153,11 @@ type (
 		// memclrAddress holds the address of memclrNoHeapPointers implemented
 		// by the Go runtime. See memclr.go.
 		memclrAddress uintptr
+		// moduleClosedPtr is a pointer to the underlying uint64 of the
+		// owning ModuleInstance.Closed field. Compiled code reads through it
+		// at every loop back-edge (when ensureTermination is on) and calls
+		// back into Go when non-zero.
+		moduleClosedPtr *uint64
 	}
 )
 
@@ -342,7 +353,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 	if c.stackTop&(16-1) != 0 {
 		panic("BUG: stack must be aligned to 16 bytes")
 	}
-	entrypoint(c.preambleExecutable, c.executable, c.execCtxPtr, c.parent.opaquePtr, paramResultPtr, c.stackTop)
+	c.entrypoint(c.preambleExecutable, c.executable, c.execCtxPtr, c.parent.opaquePtr, paramResultPtr, c.stackTop)
 	for {
 		switch ec := c.execCtx.exitCode; ec & wazevoapi.ExitCodeMask {
 		case wazevoapi.ExitCodeOK:
@@ -364,7 +375,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			// Old stack must be alive until the new stack is adjusted.
 			runtime.KeepAlive(oldStack)
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr, newsp, newfp)
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr, newsp, newfp)
 		case wazevoapi.ExitCodeGrowMemory:
 			mod := c.callerModuleInstance()
 			mem := mod.MemoryInstance
@@ -376,7 +387,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 				*argRes = uint64(res)
 			}
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr, uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr, uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeTableGrow:
 			mod := c.callerModuleInstance()
 			s := goCallStackView(c.execCtx.stackPointerBeforeGoCall)
@@ -384,7 +395,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			table := mod.Tables[tableIndex]
 			s[0] = uint64(uint32(int32(table.Grow(num, ref))))
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeCallGoFunction:
 			index := wazevoapi.GoFunctionIndexFromExitCode(ec)
@@ -397,7 +408,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			}()
 			// Back to the native code.
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeCallGoFunctionWithListener:
 			index := wazevoapi.GoFunctionIndexFromExitCode(ec)
@@ -421,7 +432,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			listener.After(ctx, callerModule, def, s)
 			// Back to the native code.
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeCallGoModuleFunction:
 			index := wazevoapi.GoFunctionIndexFromExitCode(ec)
@@ -435,7 +446,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			}()
 			// Back to the native code.
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeCallGoModuleFunctionWithListener:
 			index := wazevoapi.GoFunctionIndexFromExitCode(ec)
@@ -459,7 +470,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			listener.After(ctx, callerModule, def, s)
 			// Back to the native code.
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeCallListenerBefore:
 			stack := goCallStackView(c.execCtx.stackPointerBeforeGoCall)
@@ -469,7 +480,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			def := mod.Source.FunctionDefinition(index + mod.Source.ImportFunctionCount)
 			listener.Before(ctx, mod, def, stack[1:], c.stackIterator(false))
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeCallListenerAfter:
 			stack := goCallStackView(c.execCtx.stackPointerBeforeGoCall)
@@ -479,7 +490,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			def := mod.Source.FunctionDefinition(index + mod.Source.ImportFunctionCount)
 			listener.After(ctx, mod, def, stack[1:])
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeCheckModuleExitCode:
 			// Note: this operation must be done in Go, not native code. The reason is that
@@ -489,7 +500,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 				panic(err)
 			}
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeRefFunc:
 			mod := c.callerModuleInstance()
@@ -498,7 +509,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			ref := mod.Engine.FunctionInstanceReference(funcIndex)
 			s[0] = uint64(ref)
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeMemoryWait32:
 			mod := c.callerModuleInstance()
@@ -518,7 +529,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			})
 			s[0] = res
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeMemoryWait64:
 			mod := c.callerModuleInstance()
@@ -538,7 +549,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			})
 			s[0] = uint64(res)
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeMemoryNotify:
 			mod := c.callerModuleInstance()
@@ -550,7 +561,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			res := mem.Notify(offset, count)
 			s[0] = uint64(res)
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeUnreachable:
 			panic(wasmruntime.ErrRuntimeUnreachable)
@@ -587,7 +598,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			// Return the exnref to compiled code via the stack slot.
 			s[0] = uint64(uintptr(unsafe.Pointer(exn)))
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeThrow:
 			// Throw trampoline: (execCtx, exnref) → ().
@@ -604,7 +615,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			}
 			c.execCtx.exceptionPtr = uintptr(unsafe.Pointer(exn))
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeNullReference:
 			panic(wasmruntime.ErrRuntimeNullReference)
@@ -646,7 +657,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 			// to read after the trampoline returns.
 			c.execCtx.caughtExceptionClauseIdx = -1
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		case wazevoapi.ExitCodeTryTableLeave:
 			// Pop the most recent try handler and restore the locals save
@@ -656,7 +667,7 @@ func (c *callEngine) callWithStack(ctx context.Context, paramResultStack []uint6
 				c.restoreLocalsSaveAreaPtr(len(c.tryHandlers) - 1)
 			}
 			c.execCtx.exitCode = wazevoapi.ExitCodeOK
-			afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
+			c.afterGoFunctionCallEntrypoint(c.execCtx.goCallReturnAddress, c.execCtxPtr,
 				uintptr(unsafe.Pointer(c.execCtx.stackPointerBeforeGoCall)), c.execCtx.framePointerBeforeGoCall)
 		default:
 			panic("BUG")

--- a/internal/engine/wazevo/entrypoint_amd64.go
+++ b/internal/engine/wazevo/entrypoint_amd64.go
@@ -2,12 +2,12 @@ package wazevo
 
 import _ "unsafe"
 
-// entrypoint is implemented by the backend.
+// entrypointAsm is implemented by the backend.
 //
-//go:linkname entrypoint github.com/tetratelabs/wazero/internal/engine/wazevo/backend/isa/amd64.entrypoint
-func entrypoint(preambleExecutable, functionExecutable *byte, executionContextPtr uintptr, moduleContextPtr *byte, paramResultStackPtr *uint64, goAllocatedStackSlicePtr uintptr)
+//go:linkname entrypointAsm github.com/tetratelabs/wazero/internal/engine/wazevo/backend/isa/amd64.entrypoint
+func entrypointAsm(preambleExecutable, functionExecutable *byte, executionContextPtr uintptr, moduleContextPtr *byte, paramResultStackPtr *uint64, goAllocatedStackSlicePtr uintptr)
 
-// entrypoint is implemented by the backend.
+// afterGoFunctionCallEntrypointAsm is implemented by the backend.
 //
-//go:linkname afterGoFunctionCallEntrypoint github.com/tetratelabs/wazero/internal/engine/wazevo/backend/isa/amd64.afterGoFunctionCallEntrypoint
-func afterGoFunctionCallEntrypoint(executable *byte, executionContextPtr uintptr, stackPointer, framePointer uintptr)
+//go:linkname afterGoFunctionCallEntrypointAsm github.com/tetratelabs/wazero/internal/engine/wazevo/backend/isa/amd64.afterGoFunctionCallEntrypoint
+func afterGoFunctionCallEntrypointAsm(executable *byte, executionContextPtr uintptr, stackPointer, framePointer uintptr)

--- a/internal/engine/wazevo/entrypoint_arm64.go
+++ b/internal/engine/wazevo/entrypoint_arm64.go
@@ -2,12 +2,12 @@ package wazevo
 
 import _ "unsafe"
 
-// entrypoint is implemented by the backend.
+// entrypointAsm is implemented by the backend.
 //
-//go:linkname entrypoint github.com/tetratelabs/wazero/internal/engine/wazevo/backend/isa/arm64.entrypoint
-func entrypoint(preambleExecutable, functionExecutable *byte, executionContextPtr uintptr, moduleContextPtr *byte, paramResultStackPtr *uint64, goAllocatedStackSlicePtr uintptr)
+//go:linkname entrypointAsm github.com/tetratelabs/wazero/internal/engine/wazevo/backend/isa/arm64.entrypoint
+func entrypointAsm(preambleExecutable, functionExecutable *byte, executionContextPtr uintptr, moduleContextPtr *byte, paramResultStackPtr *uint64, goAllocatedStackSlicePtr uintptr)
 
-// entrypoint is implemented by the backend.
+// afterGoFunctionCallEntrypointAsm is implemented by the backend.
 //
-//go:linkname afterGoFunctionCallEntrypoint github.com/tetratelabs/wazero/internal/engine/wazevo/backend/isa/arm64.afterGoFunctionCallEntrypoint
-func afterGoFunctionCallEntrypoint(executable *byte, executionContextPtr uintptr, stackPointer, framePointer uintptr)
+//go:linkname afterGoFunctionCallEntrypointAsm github.com/tetratelabs/wazero/internal/engine/wazevo/backend/isa/arm64.afterGoFunctionCallEntrypoint
+func afterGoFunctionCallEntrypointAsm(executable *byte, executionContextPtr uintptr, stackPointer, framePointer uintptr)

--- a/internal/engine/wazevo/entrypoint_other.go
+++ b/internal/engine/wazevo/entrypoint_other.go
@@ -6,10 +6,10 @@ import (
 	"runtime"
 )
 
-func entrypoint(preambleExecutable, functionExecutable *byte, executionContextPtr uintptr, moduleContextPtr *byte, paramResultStackPtr *uint64, goAllocatedStackSlicePtr uintptr) {
+func entrypointAsm(preambleExecutable, functionExecutable *byte, executionContextPtr uintptr, moduleContextPtr *byte, paramResultStackPtr *uint64, goAllocatedStackSlicePtr uintptr) {
 	panic(runtime.GOARCH)
 }
 
-func afterGoFunctionCallEntrypoint(executable *byte, executionContextPtr uintptr, stackPointer, framePointer uintptr) {
+func afterGoFunctionCallEntrypointAsm(executable *byte, executionContextPtr uintptr, stackPointer, framePointer uintptr) {
 	panic(runtime.GOARCH)
 }

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -257,48 +257,82 @@ signatures:
 	sig2: i64_v
 
 blk0: (exec_ctx:i64, module_ctx:i64)
-	Jump blk1
-
-blk1: () <-- (blk0,blk4,blk3)
-	v2:i64 = Load exec_ctx, 0x4e0
+	v2:i64 = Load exec_ctx, 0x4e8
 	v3:i64 = Load v2, 0x0
 	v4:i64 = Iconst_64 0x0
 	v5:i32 = Icmp neq, v3, v4
-	Brnz v5, blk3
-	Jump blk4
+	Brnz v5, blk1
+	Jump blk2
 
-blk2: ()
+blk1: () <-- (blk0)
+	v11:i64 = Load exec_ctx, 0x58
+	CallIndirect v11:sig2, exec_ctx
+	Jump blk2
 
-blk3: () <-- (blk1)
-	v6:i64 = Load exec_ctx, 0x58
-	CallIndirect v6:sig2, exec_ctx
-	Jump blk1
+blk2: () <-- (blk0,blk1)
+	Jump blk3
 
-blk4: () <-- (blk1)
-	Jump blk1
+blk3: () <-- (blk2,blk6)
+	v6:i64 = Load exec_ctx, 0x4e8
+	v7:i64 = Load v6, 0x0
+	v8:i64 = Iconst_64 0x0
+	v9:i32 = Icmp neq, v7, v8
+	Brnz v9, blk5
+	Jump blk6
+
+blk4: ()
+
+blk5: () <-- (blk3)
+	v10:i64 = Load exec_ctx, 0x58
+	CallIndirect v10:sig2, exec_ctx
+	Jump blk6
+
+blk6: () <-- (blk3,blk5)
+	Jump blk3
 `,
+			// Both checks have the same shape: test, cold block last, rejoin the body.
+			// blk7 and blk8 are split critical edges; both are empty fallthroughs.
 			expAfterPasses: `
 signatures:
 	sig2: i64_v
 
 blk0: (exec_ctx:i64, module_ctx:i64)
-	Jump fallthrough
-
-blk1: () <-- (blk0,blk4,blk3)
-	v2:i64 = Load exec_ctx, 0x4e0
+	v2:i64 = Load exec_ctx, 0x4e8
 	v3:i64 = Load v2, 0x0
 	v4:i64 = Iconst_64 0x0
 	v5:i32 = Icmp neq, v3, v4
-	Brnz v5, blk3
+	Brnz v5, blk1
 	Jump fallthrough
 
-blk4: () <-- (blk1)
-	Jump blk1
+blk7: () <-- (blk0)
+	Jump fallthrough
 
-blk3: () <-- (blk1)
-	v6:i64 = Load exec_ctx, 0x58
-	CallIndirect v6:sig2, exec_ctx
-	Jump blk1
+blk2: () <-- (blk7,blk1)
+	Jump fallthrough
+
+blk3: () <-- (blk2,blk6)
+	v6:i64 = Load exec_ctx, 0x4e8
+	v7:i64 = Load v6, 0x0
+	v8:i64 = Iconst_64 0x0
+	v9:i32 = Icmp neq, v7, v8
+	Brnz v9, blk5
+	Jump fallthrough
+
+blk8: () <-- (blk3)
+	Jump fallthrough
+
+blk6: () <-- (blk8,blk5)
+	Jump blk3
+
+blk5: () <-- (blk3)
+	v10:i64 = Load exec_ctx, 0x58
+	CallIndirect v10:sig2, exec_ctx
+	Jump blk6
+
+blk1: () <-- (blk0)
+	v11:i64 = Load exec_ctx, 0x58
+	CallIndirect v11:sig2, exec_ctx
+	Jump blk2
 `,
 		},
 		{

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -259,12 +259,23 @@ signatures:
 blk0: (exec_ctx:i64, module_ctx:i64)
 	Jump blk1
 
-blk1: () <-- (blk0,blk1)
-	v2:i64 = Load exec_ctx, 0x58
-	CallIndirect v2:sig2, exec_ctx
-	Jump blk1
+blk1: () <-- (blk0,blk4,blk3)
+	v2:i64 = Load exec_ctx, 0x4e0
+	v3:i64 = Load v2, 0x0
+	v4:i64 = Iconst_64 0x0
+	v5:i32 = Icmp neq, v3, v4
+	Brnz v5, blk3
+	Jump blk4
 
 blk2: ()
+
+blk3: () <-- (blk1)
+	v6:i64 = Load exec_ctx, 0x58
+	CallIndirect v6:sig2, exec_ctx
+	Jump blk1
+
+blk4: () <-- (blk1)
+	Jump blk1
 `,
 			expAfterPasses: `
 signatures:
@@ -273,9 +284,20 @@ signatures:
 blk0: (exec_ctx:i64, module_ctx:i64)
 	Jump fallthrough
 
-blk1: () <-- (blk0,blk1)
-	v2:i64 = Load exec_ctx, 0x58
-	CallIndirect v2:sig2, exec_ctx
+blk1: () <-- (blk0,blk4,blk3)
+	v2:i64 = Load exec_ctx, 0x4e0
+	v3:i64 = Load v2, 0x0
+	v4:i64 = Iconst_64 0x0
+	v5:i32 = Icmp neq, v3, v4
+	Brnz v5, blk3
+	Jump fallthrough
+
+blk4: () <-- (blk1)
+	Jump blk1
+
+blk3: () <-- (blk1)
+	v6:i64 = Load exec_ctx, 0x58
+	CallIndirect v6:sig2, exec_ctx
 	Jump blk1
 `,
 		},

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -157,6 +157,13 @@ func (l *loweringState) ctrlPeekAt(n int) (ret *controlFrame) {
 func (c *Compiler) lowerBody(entryBlk ssa.BasicBlock) {
 	c.ssaBuilder.Seal(entryBlk)
 
+	// Termination check needed on entering a call to handle tail-calls and
+	// exponential call graph shapes which do not contain loops
+	var moduleClosedSlow, body ssa.BasicBlock
+	if c.ensureTermination {
+		moduleClosedSlow, body = c.emitModuleClosedTest()
+	}
+
 	if c.needListener {
 		c.callListenerBefore()
 	}
@@ -179,6 +186,12 @@ func (c *Compiler) lowerBody(entryBlk ssa.BasicBlock) {
 			// After that, we initialize the known bounds for the new compilation target block.
 			c.initializeCurrentBlockKnownBounds()
 		}
+	}
+
+	if c.ensureTermination {
+		c.ssaBuilder.SetCurrentBlock(moduleClosedSlow)
+		c.emitCheckModuleExitCodeCall(body)
+		c.ssaBuilder.Seal(body)
 	}
 }
 
@@ -1429,36 +1442,9 @@ func (c *Compiler) lowerCurrentOpcode() {
 		c.switchTo(originalLen, loopHeader)
 
 		if c.ensureTermination {
-			// Cheap inline check: load moduleClosedPtr from execCtx, then load the
-			// ModuleInstance.Closed it points to. If zero, fall through to the loop
-			// body. If non-zero (set by the cancellation watchdog OR by an explicit
-			// module.Close from another goroutine), branch out to moduleClosedBlk,
-			// which re-enters Go to report the error.
-			//
-			// Neither load needs atomic semantics. The pointer is written once at
-			// callEngine setup; the flag is a single aligned word that only ever goes
-			// from zero to non-zero, so the worst a racing close can cost is being
-			// noticed an iteration later.
-			closedPtr := builder.AllocateInstruction().
-				AsLoad(c.execCtxPtrValue,
-					wazevoapi.ExecutionContextOffsetModuleClosedPtr.U32(),
-					ssa.TypeI64,
-				).Insert(builder).Return()
-			closed := builder.AllocateInstruction().
-				AsLoad(closedPtr, 0, ssa.TypeI64).Insert(builder).Return()
-
-			zero := builder.AllocateInstruction().AsIconst64(0).Insert(builder).Return()
-			closedNonZero := builder.AllocateInstruction().
-				AsIcmp(closed, zero, ssa.IntegerCmpCondNotEqual).Insert(builder).Return()
-
-			moduleClosedSlow, loopBody := builder.AllocateBasicBlock(), builder.AllocateBasicBlock()
-			builder.AllocateInstruction().
-				AsBrnz(closedNonZero, ssa.ValuesNil, moduleClosedSlow).
-				Insert(builder)
-			c.insertJumpToBlock(ssa.ValuesNil, loopBody)
-
-			builder.SetCurrentBlock(loopBody)
-			builder.Seal(loopBody)
+			// The slow block is left empty here and filled in at the loop's End. The body
+			// block stays unsealed until then too, since that is the slow path's way back in.
+			_, _ = c.emitModuleClosedTest()
 		}
 	case wasm.OpcodeIf:
 		bt := c.readBlockType()
@@ -1563,7 +1549,19 @@ func (c *Compiler) lowerCurrentOpcode() {
 			break // This is the very end of function.
 		case controlFrameKindLoop:
 			if c.ensureTermination {
-				c.lowerModuleClosedSlowCheck(&ctrl)
+				// The slow check body is emitted at the loop's end, rather than the more obvious location
+				// when processing the loop header, because block layout follows the instruction order. This
+				// matters on benchmarks: both amd64 and arm64 predict a forward branch is not taken until
+				// there is a branch prediction history, so making the rare path (module closed) the forward
+				// branch instead of the loop body being a forward branch provides a measurable speedup.
+
+				// when we emitted the fast path closed check, we created two successors of the loop header:
+				// the slow path check and the loop body, in that order
+				moduleClosedSlow, loopBody := ctrl.blk.Succ(0), ctrl.blk.Succ(1)
+
+				c.ssaBuilder.SetCurrentBlock(moduleClosedSlow)
+				c.emitCheckModuleExitCodeCall(loopBody)
+				c.ssaBuilder.Seal(loopBody)
 			}
 			// Loop header block can be reached from any br/br_table contained in the loop,
 			// so now that we've reached End of it, we can seal it.
@@ -5028,21 +5026,48 @@ func (c *Compiler) insertJumpToBlock(args ssa.Values, targetBlk ssa.BasicBlock) 
 	builder.InsertInstruction(jmp)
 }
 
-// lowerModuleClosedSlowCheck fills in the block a loop's module-closed check branches to when it finds
-// the flag set.
-//
-// The slow check body is emitted at the loop's end, rather than more naturally being emitted
-// in the loop header, because block layout follows the order blocks were first written to:
-// written last, this one lands after the whole loop, and the check falls through into the
-// body instead of branching to it. This matters on benchmarks: both amd64 and arm64 predict
-// a forward branch is not taken until there is a branch prediction history, so making the
-// rare path (module closed) the forward branch instead of the loop body being a forward
-// branch provides a measurable speedup.
-func (c *Compiler) lowerModuleClosedSlowCheck(ctrl *controlFrame) {
+// emitModuleClosedTest emits the cheap inline module-closed test into the current block.
+func (c *Compiler) emitModuleClosedTest() (moduleClosedSlow, notClosed ssa.BasicBlock) {
 	builder := c.ssaBuilder
 
-	moduleClosedBlk := ctrl.blk.Succ(0) // Succ 0 is the slow path branch from the loopHeader
-	builder.SetCurrentBlock(moduleClosedBlk)
+	// Load moduleClosedPtr from execCtx, then load the ModuleInstance.Closed it points to. If
+	// zero, fall through. If non-zero (set by the cancellation watchdog OR by an explicit
+	// module.Close from another goroutine), branch to a slow block that re-enters Go via the
+	// checkModuleExitCode trampoline.
+	//
+	// Neither load needs atomic semantics. The pointer is written once at callEngine setup; the
+	// flag is a single aligned word that only ever goes from zero to non-zero, so the worst a
+	// racing close can cost is being noticed one check later.
+	closedPtr := builder.AllocateInstruction().
+		AsLoad(c.execCtxPtrValue,
+			wazevoapi.ExecutionContextOffsetModuleClosedPtr.U32(),
+			ssa.TypeI64,
+		).Insert(builder).Return()
+	closed := builder.AllocateInstruction().
+		AsLoad(closedPtr, 0, ssa.TypeI64).Insert(builder).Return()
+
+	zero := builder.AllocateInstruction().AsIconst64(0).Insert(builder).Return()
+	closedNonZero := builder.AllocateInstruction().
+		AsIcmp(closed, zero, ssa.IntegerCmpCondNotEqual).Insert(builder).Return()
+
+	moduleClosedSlow, notClosed = builder.AllocateBasicBlock(), builder.AllocateBasicBlock()
+	builder.AllocateInstruction().
+		AsBrnz(closedNonZero, ssa.ValuesNil, moduleClosedSlow).
+		Insert(builder)
+	c.insertJumpToBlock(ssa.ValuesNil, notClosed)
+
+	// This branch is the slow block's only way in, so it is already complete. notClosed is
+	// not: the caller decides whether the slow path rejoins it.
+	builder.Seal(moduleClosedSlow)
+
+	builder.SetCurrentBlock(notClosed)
+	return
+}
+
+// emitCheckModuleExitCodeCall calls the trampoline that re-enters Go to perform the full,
+// atomic check for module closed. It normally panics with the exit error and never comes back.
+func (c *Compiler) emitCheckModuleExitCodeCall(target ssa.BasicBlock) {
+	builder := c.ssaBuilder
 
 	checkModuleExitCodePtr := builder.AllocateInstruction().
 		AsLoad(c.execCtxPtrValue,
@@ -5053,14 +5078,7 @@ func (c *Compiler) lowerModuleClosedSlowCheck(ctrl *controlFrame) {
 		AsCallIndirect(checkModuleExitCodePtr, &c.checkModuleExitCodeSig,
 			c.allocateVarLengthValues(1, c.execCtxPtrValue)).
 		Insert(builder)
-
-	loopHeader := ctrl.blk
-	backArgs := c.allocateVarLengthValues(loopHeader.Params())
-	for i := 0; i < loopHeader.Params(); i++ {
-		backArgs = backArgs.Append(builder.VarLengthPool(), loopHeader.Param(i))
-	}
-	c.insertJumpToBlock(backArgs, loopHeader)
-	builder.Seal(moduleClosedBlk)
+	c.insertJumpToBlock(ssa.ValuesNil, target)
 }
 
 func (c *Compiler) insertIntegerExtend(signed bool, from, to byte) {

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -1429,16 +1429,36 @@ func (c *Compiler) lowerCurrentOpcode() {
 		c.switchTo(originalLen, loopHeader)
 
 		if c.ensureTermination {
-			checkModuleExitCodePtr := builder.AllocateInstruction().
+			// Cheap inline check: load moduleClosedPtr from execCtx, then load the
+			// ModuleInstance.Closed it points to. If zero, fall through to the loop
+			// body. If non-zero (set by the cancellation watchdog OR by an explicit
+			// module.Close from another goroutine), branch out to moduleClosedBlk,
+			// which re-enters Go to report the error.
+			//
+			// Neither load needs atomic semantics. The pointer is written once at
+			// callEngine setup; the flag is a single aligned word that only ever goes
+			// from zero to non-zero, so the worst a racing close can cost is being
+			// noticed an iteration later.
+			closedPtr := builder.AllocateInstruction().
 				AsLoad(c.execCtxPtrValue,
-					wazevoapi.ExecutionContextOffsetCheckModuleExitCodeTrampolineAddress.U32(),
+					wazevoapi.ExecutionContextOffsetModuleClosedPtr.U32(),
 					ssa.TypeI64,
 				).Insert(builder).Return()
+			closed := builder.AllocateInstruction().
+				AsLoad(closedPtr, 0, ssa.TypeI64).Insert(builder).Return()
 
-			args := c.allocateVarLengthValues(1, c.execCtxPtrValue)
+			zero := builder.AllocateInstruction().AsIconst64(0).Insert(builder).Return()
+			closedNonZero := builder.AllocateInstruction().
+				AsIcmp(closed, zero, ssa.IntegerCmpCondNotEqual).Insert(builder).Return()
+
+			moduleClosedSlow, loopBody := builder.AllocateBasicBlock(), builder.AllocateBasicBlock()
 			builder.AllocateInstruction().
-				AsCallIndirect(checkModuleExitCodePtr, &c.checkModuleExitCodeSig, args).
+				AsBrnz(closedNonZero, ssa.ValuesNil, moduleClosedSlow).
 				Insert(builder)
+			c.insertJumpToBlock(ssa.ValuesNil, loopBody)
+
+			builder.SetCurrentBlock(loopBody)
+			builder.Seal(loopBody)
 		}
 	case wasm.OpcodeIf:
 		bt := c.readBlockType()
@@ -1542,6 +1562,9 @@ func (c *Compiler) lowerCurrentOpcode() {
 		case controlFrameKindFunction:
 			break // This is the very end of function.
 		case controlFrameKindLoop:
+			if c.ensureTermination {
+				c.lowerModuleClosedSlowCheck(&ctrl)
+			}
 			// Loop header block can be reached from any br/br_table contained in the loop,
 			// so now that we've reached End of it, we can seal it.
 			builder.Seal(ctrl.blk)
@@ -5003,6 +5026,41 @@ func (c *Compiler) insertJumpToBlock(args ssa.Values, targetBlk ssa.BasicBlock) 
 	jmp := builder.AllocateInstruction()
 	jmp.AsJump(args, targetBlk)
 	builder.InsertInstruction(jmp)
+}
+
+// lowerModuleClosedSlowCheck fills in the block a loop's module-closed check branches to when it finds
+// the flag set.
+//
+// The slow check body is emitted at the loop's end, rather than more naturally being emitted
+// in the loop header, because block layout follows the order blocks were first written to:
+// written last, this one lands after the whole loop, and the check falls through into the
+// body instead of branching to it. This matters on benchmarks: both amd64 and arm64 predict
+// a forward branch is not taken until there is a branch prediction history, so making the
+// rare path (module closed) the forward branch instead of the loop body being a forward
+// branch provides a measurable speedup.
+func (c *Compiler) lowerModuleClosedSlowCheck(ctrl *controlFrame) {
+	builder := c.ssaBuilder
+
+	moduleClosedBlk := ctrl.blk.Succ(0) // Succ 0 is the slow path branch from the loopHeader
+	builder.SetCurrentBlock(moduleClosedBlk)
+
+	checkModuleExitCodePtr := builder.AllocateInstruction().
+		AsLoad(c.execCtxPtrValue,
+			wazevoapi.ExecutionContextOffsetCheckModuleExitCodeTrampolineAddress.U32(),
+			ssa.TypeI64,
+		).Insert(builder).Return()
+	builder.AllocateInstruction().
+		AsCallIndirect(checkModuleExitCodePtr, &c.checkModuleExitCodeSig,
+			c.allocateVarLengthValues(1, c.execCtxPtrValue)).
+		Insert(builder)
+
+	loopHeader := ctrl.blk
+	backArgs := c.allocateVarLengthValues(loopHeader.Params())
+	for i := 0; i < loopHeader.Params(); i++ {
+		backArgs = backArgs.Append(builder.VarLengthPool(), loopHeader.Param(i))
+	}
+	c.insertJumpToBlock(backArgs, loopHeader)
+	builder.Seal(moduleClosedBlk)
 }
 
 func (c *Compiler) insertIntegerExtend(signed bool, from, to byte) {

--- a/internal/engine/wazevo/module_engine.go
+++ b/internal/engine/wazevo/module_engine.go
@@ -222,6 +222,8 @@ func (m *moduleEngine) NewFunction(index wasm.Index) api.Function {
 	ce.execCtx.tryTableLeaveTrampolineAddress = sharedFunctions.tryTableLeaveAddress
 	ce.execCtx.memmoveAddress = memmovPtr
 	ce.execCtx.memclrAddress = memclrPtr
+	ce.execCtx.moduleClosedPtr = (*uint64)(unsafe.Pointer(&m.module.Closed))
+	ce.entrypoint, ce.afterGoFunctionCallEntrypoint = entrypoints(p.ensureTermination)
 	ce.init()
 	return ce
 }

--- a/internal/engine/wazevo/runtime_syscall.go
+++ b/internal/engine/wazevo/runtime_syscall.go
@@ -1,0 +1,64 @@
+package wazevo
+
+import (
+	_ "unsafe" // for go:linkname
+)
+
+// runtime_entersyscall and runtime_exitsyscall mark the goroutine as being
+// in a syscall, which detaches its P. This lets the Go runtime's sysmon
+// retake the P after ~10ms and run other goroutines on it, even if the
+// wasm goroutine is in a long-running native loop.
+//
+// Same trick used by gvisor (see runtime/proc.go: comment
+// on entersyscallblock — the runtime team has committed to not changing
+// the type signatures of these entry points).
+
+//go:linkname runtime_entersyscall runtime.entersyscall
+func runtime_entersyscall()
+
+//go:linkname runtime_exitsyscall runtime.exitsyscall
+func runtime_exitsyscall()
+
+type (
+	// entrypointFn enters compiled code at a function's entry preamble.
+	entrypointFn func(preambleExecutable, functionExecutable *byte, executionContextPtr uintptr, moduleContextPtr *byte, paramResultStackPtr *uint64, goAllocatedStackSlicePtr uintptr)
+	// afterGoFunctionCallEntrypointFn re-enters compiled code after a Go-side dispatcher
+	// iteration (host call, FailIfClosed, stack grow, etc.).
+	afterGoFunctionCallEntrypointFn func(executable *byte, executionContextPtr uintptr, stackPointer, framePointer uintptr)
+)
+
+// entrypoints returns the pair of functions a callEngine of a module compiled with the given
+// ensureTermination enters compiled code through.
+//
+// Only ensureTermination needs the syscall bracketing: its loops check ModuleInstance.Closed
+// themselves instead of calling back into Go, so this goroutine has to have released its P for
+// the watchdog goroutine to ever run and set that flag. Without it nothing has to run while
+// wasm does, and the bracketing would just be overhead on every call and every host call.
+func entrypoints(ensureTermination bool) (entrypointFn, afterGoFunctionCallEntrypointFn) {
+	if ensureTermination {
+		return entrypointInSyscall, afterGoFunctionCallEntrypointInSyscall
+	}
+	return entrypointAsm, afterGoFunctionCallEntrypointAsm
+}
+
+// entrypointInSyscall is entrypointAsm bracketed with entersyscall / exitsyscall so the Go
+// runtime can retake this goroutine's P while wasm is running. Marked nosplit because
+// entersyscall sets throwsplit and we must not grow the stack between entersyscall and
+// exitsyscall.
+//
+//go:nosplit
+func entrypointInSyscall(preambleExecutable, functionExecutable *byte, executionContextPtr uintptr, moduleContextPtr *byte, paramResultStackPtr *uint64, goAllocatedStackSlicePtr uintptr) {
+	runtime_entersyscall()
+	entrypointAsm(preambleExecutable, functionExecutable, executionContextPtr, moduleContextPtr, paramResultStackPtr, goAllocatedStackSlicePtr)
+	runtime_exitsyscall()
+}
+
+// afterGoFunctionCallEntrypointInSyscall is afterGoFunctionCallEntrypointAsm with the same
+// syscall bracketing as entrypointInSyscall, and the same nosplit constraint.
+//
+//go:nosplit
+func afterGoFunctionCallEntrypointInSyscall(executable *byte, executionContextPtr uintptr, stackPointer, framePointer uintptr) {
+	runtime_entersyscall()
+	afterGoFunctionCallEntrypointAsm(executable, executionContextPtr, stackPointer, framePointer)
+	runtime_exitsyscall()
+}

--- a/internal/engine/wazevo/wazevo_test.go
+++ b/internal/engine/wazevo/wazevo_test.go
@@ -81,4 +81,5 @@ func Test_ExecutionContextOffsets(t *testing.T) {
 	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.exceptionParamsPtr)), wazevoapi.ExecutionContextOffsetExceptionParamsPtr)
 	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.caughtExceptionClauseIdx)), wazevoapi.ExecutionContextOffsetCaughtExceptionClauseIdx)
 	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.localsSaveAreaPtr)), wazevoapi.ExecutionContextOffsetLocalsSaveAreaPtr)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.moduleClosedPtr)), wazevoapi.ExecutionContextOffsetModuleClosedPtr)
 }

--- a/internal/engine/wazevo/wazevoapi/offsetdata.go
+++ b/internal/engine/wazevo/wazevoapi/offsetdata.go
@@ -76,6 +76,11 @@ const (
 	ExecutionContextOffsetLocalsSaveAreaPtr Offset = 1240
 	// ExecutionContextOffsetMemclrAddress is the offset of `memclrAddress` in executionContext.
 	ExecutionContextOffsetMemclrAddress Offset = 1248
+	// ExecutionContextOffsetModuleClosedPtr is the offset of `moduleClosedPtr`
+	// (a *uint64 pointing to ModuleInstance.Closed's underlying value).
+	// Read by compiled code at every loop back-edge when ensureTermination is on:
+	// load the pointer, then load the uint64 it points to, branch if non-zero.
+	ExecutionContextOffsetModuleClosedPtr Offset = 1256
 )
 
 // ModuleContextOffsetData allows the compilers to get the information about offsets to the fields of wazevo.moduleContextOpaque,

--- a/internal/integration_test/bench/call_overhead_bench_test.go
+++ b/internal/integration_test/bench/call_overhead_bench_test.go
@@ -1,0 +1,127 @@
+package bench
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/testing/binaryencoding"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
+)
+
+// BenchmarkCallEntryCheckOverhead isolates what `WithCloseOnContextDone(true)` costs per
+// *call*, as opposed to per loop iteration (which BenchmarkContextDoneOverhead covers).
+// Both engines emit the function-entry check, so both are measured.
+//
+//   - "tree" is a loop-free call tree, so every check it pays is a function-entry check:
+//     f_i calls f_{i+1} twice down to a nop leaf, for 2^depth-1 invocations and zero loop
+//     back-edges.
+//   - "call_loop" is a loop whose body does nothing but call a nop leaf, so each iteration
+//     pays one loop-header check plus one function-entry check.
+func BenchmarkCallEntryCheckOverhead(b *testing.B) {
+	const treeDepth = 20 // 2^20-1 == ~1.05M invocations per call.
+	const loopIters = 1_000_000
+
+	tree := buildCallTreeModule(treeDepth)
+	callLoop := buildCallLoopModule()
+
+	for _, engine := range []struct {
+		name   string
+		newCfg func() wazero.RuntimeConfig
+	}{
+		{"compiler", wazero.NewRuntimeConfigCompiler},
+		{"interpreter", wazero.NewRuntimeConfigInterpreter},
+	} {
+		b.Run(engine.name, func(b *testing.B) {
+			if engine.name == "compiler" && !platform.CompilerSupported() {
+				b.Skip()
+			}
+			for _, ensure := range []bool{false, true} {
+				label := "without_close_on_ctx_done"
+				if ensure {
+					label = "with_close_on_ctx_done"
+				}
+				b.Run(label, func(b *testing.B) {
+					ctx := context.Background()
+					cfg := engine.newCfg().WithCloseOnContextDone(ensure)
+					r := wazero.NewRuntimeWithConfig(ctx, cfg)
+					defer r.Close(ctx)
+
+					treeMod, err := r.Instantiate(ctx, tree)
+					require.NoError(b, err)
+					loopMod, err := r.Instantiate(ctx, callLoop)
+					require.NoError(b, err)
+
+					treeFn := treeMod.ExportedFunction("run")
+					loopFn := loopMod.ExportedFunction("run")
+
+					b.Run("tree_1M_calls", func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							if _, err := treeFn.Call(ctx); err != nil {
+								b.Fatal(err)
+							}
+						}
+					})
+					b.Run("call_loop_1M", func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							if _, err := loopFn.Call(ctx, loopIters); err != nil {
+								b.Fatal(err)
+							}
+						}
+					})
+				})
+			}
+		})
+	}
+}
+
+// buildCallTreeModule builds a loop-free call tree: f_i calls f_{i+1} twice, down to a nop
+// leaf. f_0 is exported as "run" and performs 2^depth-1 total invocations.
+func buildCallTreeModule(depth int) []byte {
+	funcs := make([]wasm.Index, depth)
+	code := make([]wasm.Code, depth)
+	for i := 0; i < depth; i++ {
+		funcs[i] = 0
+		if i == depth-1 {
+			code[i] = wasm.Code{Body: []byte{0x01 /* nop */, opEnd}}
+			continue
+		}
+		callee := byte(i + 1) // depth stays below 128, so a single-byte LEB128 index is fine.
+		code[i] = wasm.Code{Body: []byte{0x10 /* call */, callee, 0x10, callee, opEnd}}
+	}
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection:     []wasm.FunctionType{{ParamNumInUint64: 0, ResultNumInUint64: 0}},
+		FunctionSection: funcs,
+		ExportSection:   []wasm.Export{{Name: "run", Type: wasm.ExternTypeFunc, Index: 0}},
+		CodeSection:     code,
+	})
+}
+
+// buildCallLoopModule builds `(func (param $n i64) (loop (call $leaf) (br_if $L ...)))`,
+// so each iteration pays a loop-header check and a function-entry check.
+//
+//	Locals of "run": 0=$n, 1=$i.
+func buildCallLoopModule() []byte {
+	const i64 = wasm.ValueTypeI64
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection: []wasm.FunctionType{
+			{Params: []wasm.ValueType{i64}, ParamNumInUint64: 1},
+			{},
+		},
+		FunctionSection: []wasm.Index{0, 1},
+		ExportSection:   []wasm.Export{{Name: "run", Type: wasm.ExternTypeFunc, Index: 0}},
+		CodeSection: []wasm.Code{
+			{LocalTypes: []wasm.ValueType{i64}, Body: []byte{
+				opLoop, bt0x40,
+				0x10, 0x01, // call $leaf
+				opLocalGet, 1, opI64Const, 0x01, opI64Add, opLocalSet, 1, // i++
+				opLocalGet, 1, opLocalGet, 0, opI64LtS, opBrIf, 0, // if i < n: continue
+				opEnd,
+				opEnd,
+			}},
+			{Body: []byte{0x01 /* nop */, opEnd}},
+		},
+	})
+}

--- a/internal/integration_test/bench/context_done_bench_test.go
+++ b/internal/integration_test/bench/context_done_bench_test.go
@@ -1,0 +1,167 @@
+package bench
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/testing/binaryencoding"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
+)
+
+// BenchmarkContextDoneOverhead isolates the cost paid by `WithCloseOnContextDone(true)`.
+//
+// Every wasm `loop` opcode header emits a module closed check when ensureTermination is on;
+// every Wasm call also spawns a watchdog goroutine via CloseModuleOnCanceledOrTimeout.
+// We vary iterations-per-call so the two cost regimes can be separated:
+//
+//   - "short" (1k iters/call): per-call costs (goroutine spawn + close-chan wakeup) dominate.
+//   - "long"  (10M iters/call): per-iteration trampoline cost dominates; per-call cost is amortized.
+//
+// "tight" = pure integer loop (back-edge is the only work).
+// "mem"   = same loop but reads i64 from linear memory each iteration.
+func BenchmarkContextDoneOverhead(b *testing.B) {
+	if !platform.CompilerSupported() {
+		b.Skip()
+	}
+
+	bin := buildContextDoneModule(b)
+
+	itersByName := []struct {
+		name  string
+		iters uint64
+	}{
+		{"short_1k", 1_000},
+		{"long_10M", 10_000_000},
+	}
+
+	for _, ensure := range []bool{false, true} {
+		ensure := ensure
+		label := "without"
+		if ensure {
+			label = "with"
+		}
+		b.Run(label+"_close_on_ctx_done", func(b *testing.B) {
+			ctx := context.Background()
+			cfg := wazero.NewRuntimeConfigCompiler().WithCloseOnContextDone(ensure)
+			r := wazero.NewRuntimeWithConfig(ctx, cfg)
+			defer r.Close(ctx)
+
+			mod, err := r.Instantiate(ctx, bin)
+			require.NoError(b, err)
+
+			tightLoop := mod.ExportedFunction("tight_loop")
+			memLoop := mod.ExportedFunction("mem_loop")
+
+			for _, sz := range itersByName {
+				sz := sz
+				b.Run("tight/"+sz.name, func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						if _, err := tightLoop.Call(ctx, sz.iters); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+				b.Run("mem/"+sz.name, func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						if _, err := memLoop.Call(ctx, sz.iters); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+// buildContextDoneModule produces a wasm module with two exported functions:
+//
+//	(func (export "tight_loop") (param i64) (result i64) ...)
+//	(func (export "mem_loop")   (param i64) (result i64) ...)
+//
+// Both run a tight loop for `n` iterations. mem_loop additionally reads an i64 from
+// linear memory each iteration. Hand-encoded to avoid pulling in a wat parser.
+func buildContextDoneModule(b *testing.B) []byte {
+	b.Helper()
+	const i64 = wasm.ValueTypeI64
+
+	bin := binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection: []wasm.FunctionType{{
+			Params:           []wasm.ValueType{i64},
+			Results:          []wasm.ValueType{i64},
+			ParamNumInUint64: 1, ResultNumInUint64: 1,
+		}},
+		FunctionSection: []wasm.Index{0, 0},
+		MemorySection:   &wasm.Memory{Min: 1, Cap: 1, Max: 1, IsMaxEncoded: true},
+		ExportSection: []wasm.Export{
+			{Name: "tight_loop", Type: wasm.ExternTypeFunc, Index: 0},
+			{Name: "mem_loop", Type: wasm.ExternTypeFunc, Index: 1},
+		},
+		CodeSection: []wasm.Code{
+			{LocalTypes: []wasm.ValueType{i64, i64}, Body: tightLoopBody()},
+			{LocalTypes: []wasm.ValueType{i64, i64}, Body: memLoopBody()},
+		},
+	})
+	return bin
+}
+
+// Wasm opcodes used below.
+const (
+	opLocalGet   = 0x20
+	opLocalSet   = 0x21
+	opI64Const   = 0x42
+	opI64Add     = 0x7c
+	opI64And     = 0x83
+	opI64LtS     = 0x53
+	opI64Load    = 0x29
+	opI32WrapI64 = 0xa7
+	opLoop       = 0x03
+	opEnd        = 0x0b
+	opBrIf       = 0x0d
+	bt0x40       = 0x40 // empty block type
+)
+
+// tightLoopBody:
+//
+//	(func (param $n i64) (result i64) (local $i i64) (local $sum i64)
+//	  (loop $L
+//	    (local.set $sum (i64.add (local.get $sum) (local.get $i)))
+//	    (local.set $i   (i64.add (local.get $i) (i64.const 1)))
+//	    (br_if $L (i64.lt_s (local.get $i) (local.get $n))))
+//	  (local.get $sum))
+//
+// Locals: 0=$n, 1=$i, 2=$sum.
+func tightLoopBody() []byte {
+	return []byte{
+		opLoop, bt0x40,
+		opLocalGet, 2, opLocalGet, 1, opI64Add, opLocalSet, 2, // sum += i
+		opLocalGet, 1, opI64Const, 0x01, opI64Add, opLocalSet, 1, // i++
+		opLocalGet, 1, opLocalGet, 0, opI64LtS, opBrIf, 0, // if i < n: continue
+		opEnd,
+		opLocalGet, 2,
+		opEnd,
+	}
+}
+
+// memLoopBody: same as tightLoopBody, but `sum += mem[(i & 0xfff8)]` instead of `sum += i`.
+// The mask keeps the address inside the single-page memory and 8-byte aligned.
+func memLoopBody() []byte {
+	// i64.const 0xfff8 in signed leb128: 0xf8 0xff 0x03
+	return []byte{
+		opLoop, bt0x40,
+		opLocalGet, 2, // sum
+		opLocalGet, 1, // i
+		opI64Const, 0xf8, 0xff, 0x03, // 0xfff8
+		opI64And,              // i & mask
+		opI32WrapI64,          // -> i32 address
+		opI64Load, 0x03, 0x00, // align=3 offset=0
+		opI64Add, opLocalSet, 2, // sum += mem[i & mask]
+		opLocalGet, 1, opI64Const, 0x01, opI64Add, opLocalSet, 1, // i++
+		opLocalGet, 1, opLocalGet, 0, opI64LtS, opBrIf, 0,
+		opEnd,
+		opLocalGet, 2,
+		opEnd,
+	}
+}

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -184,6 +184,29 @@ func testEnsureTerminationOnClose(t *testing.T, r wazero.Runtime) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "module closed with exit_code(2)")
 	})
+
+	// Verifies cancellation propagates even when the wasm goroutine is the only
+	// thing on the only P. This is the worst case: under GOMAXPROCS=1, with a
+	// pure tight wasm loop, the wasm goroutine must voluntarily release the P
+	// (via runtime.entersyscall around the native-code segment, on wazevo) so
+	// that the watchdog goroutine can run and set ModuleInstance.Closed.
+	// Without that, no other goroutine could fire to mark the call canceled,
+	// and the call would hang.
+	t.Run("context cancel under GOMAXPROCS=1", func(t *testing.T) {
+		_, infinite := newInfiniteLoopFn(t)
+
+		prev := runtime.GOMAXPROCS(1)
+		t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+		_, err = infinite.Call(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "module closed with context canceled")
+	})
 }
 
 func testUserDefinedPrimitiveHostFunc(t *testing.T, r wazero.Runtime) {

--- a/internal/integration_test/engine/termination_shapes_test.go
+++ b/internal/integration_test/engine/termination_shapes_test.go
@@ -1,0 +1,137 @@
+package adhoc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/testing/binaryencoding"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
+)
+
+// Guest code can run unboundedly without ever crossing a `loop` back-edge, which used to be
+// the only place WithCloseOnContextDone emitted its module-closed check. Both shapes below
+// ran forever under a canceled context before the check was also emitted at function entry.
+//
+// Wasm's structured control flow makes `loop` the only backward branch within a function, so
+// the call graph is the only other way to build one.
+
+const (
+	opNop        = 0x01
+	opEnd        = 0x0b
+	opCall       = 0x10
+	opReturnCall = 0x12
+)
+
+func voidFuncType() wasm.FunctionType {
+	return wasm.FunctionType{ParamNumInUint64: 0, ResultNumInUint64: 0}
+}
+
+// tailRecursionModule is infinite `return_call` self-recursion. The tail call reuses the
+// frame, so this runs forever at a constant stack depth with no `loop` opcode anywhere.
+func tailRecursionModule() []byte {
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection:     []wasm.FunctionType{voidFuncType()},
+		FunctionSection: []wasm.Index{0},
+		ExportSection:   []wasm.Export{{Name: "run", Type: wasm.ExternTypeFunc, Index: 0}},
+		CodeSection: []wasm.Code{
+			{Body: []byte{opReturnCall, 0x00, opEnd}},
+		},
+	})
+}
+
+// callTreeModule builds a loop-free exponential call tree: f_i calls f_{i+1} twice, so f_0
+// performs 2^(n-1) calls while never exceeding a stack depth of n.
+func callTreeModule(n int) []byte {
+	funcs := make([]wasm.Index, n)
+	code := make([]wasm.Code, n)
+	for i := 0; i < n; i++ {
+		funcs[i] = 0
+		if i == n-1 {
+			code[i] = wasm.Code{Body: []byte{opNop, opEnd}}
+			continue
+		}
+		callee := byte(i + 1) // n stays below 128, so a single-byte LEB128 index is fine.
+		code[i] = wasm.Code{Body: []byte{opCall, callee, opCall, callee, opEnd}}
+	}
+	return binaryencoding.EncodeModule(&wasm.Module{
+		TypeSection:     []wasm.FunctionType{voidFuncType()},
+		FunctionSection: funcs,
+		ExportSection:   []wasm.Export{{Name: "run", Type: wasm.ExternTypeFunc, Index: 0}},
+		CodeSection:     code,
+	})
+}
+
+// requireInterrupted calls "run" under a context that expires after timeout and requires the
+// call to come back with the cancellation error. A regression fails the test at hardLimit
+// rather than hanging it.
+func requireInterrupted(t *testing.T, newCfg func() wazero.RuntimeConfig, bin []byte) {
+	t.Helper()
+
+	const timeout = 200 * time.Millisecond
+	const hardLimit = 30 * time.Second
+
+	cfg := newCfg().
+		WithCoreFeatures(api.CoreFeaturesV2 | experimental.CoreFeaturesTailCall).
+		WithCloseOnContextDone(true)
+
+	r := wazero.NewRuntimeWithConfig(context.Background(), cfg)
+	defer r.Close(context.Background())
+
+	mod, err := r.Instantiate(context.Background(), bin)
+	require.NoError(t, err)
+	run := mod.ExportedFunction("run")
+	require.NotNil(t, run)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, callErr := run.Call(ctx)
+		done <- callErr
+	}()
+
+	select {
+	case callErr := <-done:
+		require.Error(t, callErr)
+		require.Contains(t, callErr.Error(), "module closed with context deadline exceeded")
+	case <-time.After(hardLimit):
+		t.Fatal("call was never interrupted: the module-closed check is not reached on this shape")
+	}
+}
+
+func TestEnsureTerminationWithoutLoops(t *testing.T) {
+	engines := []struct {
+		name   string
+		newCfg func() wazero.RuntimeConfig
+	}{
+		{"compiler", wazero.NewRuntimeConfigCompiler},
+		{"interpreter", wazero.NewRuntimeConfigInterpreter},
+	}
+
+	shapes := []struct {
+		name string
+		bin  []byte
+	}{
+		{"exponential call tree", callTreeModule(45)},
+		{"tail call self recursion", tailRecursionModule()},
+	}
+
+	for _, eng := range engines {
+		for _, sh := range shapes {
+			t.Run(eng.name+"/"+sh.name, func(t *testing.T) {
+				if eng.name == "compiler" && !platform.CompilerSupported() {
+					t.Skip()
+				}
+				t.Parallel()
+				requireInterrupted(t, eng.newCfg, sh.bin)
+			})
+		}
+	}
+}


### PR DESCRIPTION
Currently, when WithCloseOnContextDone is true, each loop iteration calls into Go to check if the module is closed. This costs about 12ns per loop iteration on a MacBook M4. The call back in to Go is necessary to ensure that other goroutines run if no cores set according to GOMAXPROCS are available.

We replace this with two constructs: first, a call to runtime.entersyscall/runtime.exitsyscall surrounding the call to asm implemented entrypoint. This is the same mechanism used by the Go runtime for calls that exit the Go runtime like syscalls, or cgo calls. This indicates to the Go scheduler that the current goroutine is now executing external code, and other Go code can be scheduled.
    
Next, we replace the call to check exit code that returns to Go with a direct check of the field in the module (indirected through a pointer stored in executionContext).

Since Go code is now never blocked from running due to WASM code this cheap check is safe since the cancellation goroutine can ensure that the module is closed when the context associated with it is closed.

While working on this, I discovered an additional problem: two code shapes that effectively ignore termination since they execute for large amounts of time without ever looping. First, an exponential call pattern (e.g. func0 calls func1 twice, func1 calls func2 twice, ..., funcN calls funcNplus1 twice) - this will not be limited by stack depth before it gets to effectively infinite numbers. Second, tail calls can recurse without ever running a loop and without growing the stack. A new test demonstrates both of these cases.

To alleviate this problem, I added termination checks to function entries, which covers both cases. This adds a tiny amount of overhead to each function call, only when ensuring termination.

This should resolve #2466.

    

    