### PR TITLE
cmd/wazero: exit non-zero on an invalid -listen or -mount

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -415,6 +415,7 @@ func validateMounts(mounts sliceFlag, stdErr logging.Writer) (rc int, rootPath s
 			return 1, rootPath, config
 		} else if !stat.IsDir() {
 			fmt.Fprintf(stdErr, "invalid mount: path %q is not a directory\n", dir)
+			return 1, rootPath, config
 		}
 
 		root := sysfs.DirFS(dir)
@@ -437,12 +438,12 @@ func validateListens(listens sliceFlag, stdErr logging.Writer) (rc int, config s
 		idx := strings.LastIndexByte(listen, ':')
 		if idx < 0 {
 			fmt.Fprintln(stdErr, "invalid listen")
-			return rc, config
+			return 1, config
 		}
 		port, err := strconv.Atoi(listen[idx+1:])
 		if err != nil {
 			fmt.Fprintln(stdErr, "invalid listen port:", err)
-			return rc, config
+			return 1, config
 		}
 		if config == nil {
 			config = sock.NewConfig()

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -521,12 +521,24 @@ func TestRun_Errors(t *testing.T) {
 			args:    []string{"--mount=te", "testdata/wasi_env.wasm"},
 		},
 		{
+			message: "is not a directory",
+			args:    []string{"--mount=" + notWasmPath, "testdata/wasi_env.wasm"},
+		},
+		{
 			message: "invalid cachedir",
 			args:    []string{"--cachedir", notWasmPath, wasmPath},
 		},
 		{
 			message: "timeout duration may not be negative",
 			args:    []string{"-timeout=-10s", wasmPath},
+		},
+		{
+			message: "invalid listen",
+			args:    []string{"--listen=8080", wasmPath},
+		},
+		{
+			message: "invalid listen port",
+			args:    []string{"--listen=localhost:abc", wasmPath},
 		},
 	}
 

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -522,7 +522,7 @@ func TestRun_Errors(t *testing.T) {
 		},
 		{
 			message: "is not a directory",
-			args:    []string{"--mount=" + notWasmPath, "testdata/wasi_env.wasm"},
+			args:    []string{"--mount=" + notWasmPath + ":/", "testdata/wasi_env.wasm"},
 		},
 		{
 			message: "invalid cachedir",


### PR DESCRIPTION
`cmd/wazero/wazero_test.go` doesn't contain the word `listen` anywhere, and the one `invalid mount` row in `TestRun_Errors` has `// not found` sat next to it. Which is proably why nobody's noticed that three of the four cases below print an error and then run the module regardless.

Each row is `wazero run <flags> cmd/wazero/testdata/wasi_arg.wasm`, from the repo root:

| flags | stderr | exit |
| --- | --- | --- |
| `-mount=/nope/nope` | `invalid mount: path "/nope/nope" error: stat ...` | 1 |
| `-mount=cmd/wazero/testdata/fs/bear.txt` | `invalid mount: path "..." is not a directory` | 0 |
| `-listen 8080` | `invalid listen` | 0 |
| `-listen localhost:abc` | `invalid listen port: strconv.Atoi: parsing "abc": invalid syntax` | 0 |

Only the top one's right. The other three start the guest with no mount and no listener and still hand back 0, so a CI job wrapping `wazero` passes on a server that never listened.

The listen side is worse than it looks: `validateListens` never assigns the named `rc` it returns, so the `rc != 0` branch in its caller has never fired.

Three lines of fix against twelve of test, which is a daft ratio - they're three more rows in the existing `TestRun_Errors` table though, rather than a new harness.

The mount change is the bit with any chance of biting someone. If you'd been pointing `-mount` at a file and getting away with it, thats exit 1 now instead of a `DirFS` over a regular file. Nothing in the repo does that as far as I can see, I havent looked outside it.
