### PR TITLE
wazevo: lower memory.fill to inline stores (SIMD/memclr version)

### DIFF
--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -144,6 +144,9 @@ type (
 		// localsSaveAreaPtr points to the tryHandler's localsSaveArea slice
 		// backing array. Handlers load locals from this slice.
 		localsSaveAreaPtr uintptr
+		// memclrAddress holds the address of memclrNoHeapPointers implemented
+		// by the Go runtime. See memclr.go.
+		memclrAddress uintptr
 	}
 )
 

--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -30,6 +30,7 @@ type Compiler struct {
 	tableGrowSig           ssa.Signature
 	refFuncSig             ssa.Signature
 	memmoveSig             ssa.Signature
+	memclrSig              ssa.Signature
 	ensureTermination      bool
 
 	// Followings are reset by per function.
@@ -302,6 +303,13 @@ func (c *Compiler) declareSignatures(listenerOn bool) {
 		Results: []ssa.Type{},
 	}
 	c.ssaBuilder.DeclareSignature(&c.tryTableLeaveSig)
+
+	c.memclrSig = ssa.Signature{
+		ID: c.tryTableLeaveSig.ID + 1,
+		// ptr and the byte count.
+		Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64},
+	}
+	c.ssaBuilder.DeclareSignature(&c.memclrSig)
 }
 
 // SignatureForWasmFunctionType returns the ssa.Signature for the given wasm.FunctionType.

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -3100,6 +3100,8 @@ func TestCompiler_declareSignatures(t *testing.T) {
 			{ID: 13, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64}},
 			{ID: 14, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64}},
 			{ID: 15, Params: []ssa.Type{ssa.TypeI64}},
+			// memclr signature.
+			{ID: 16, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64}},
 		}
 
 		require.Equal(t, len(expected), len(declaredSigs))
@@ -3144,6 +3146,8 @@ func TestCompiler_declareSignatures(t *testing.T) {
 			{ID: 21, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64}},
 			{ID: 22, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64}},
 			{ID: 23, Params: []ssa.Type{ssa.TypeI64}},
+			// memclr signature.
+			{ID: 24, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64}},
 		}
 		require.Equal(t, len(expected), len(declaredSigs))
 		for i := 0; i < len(declaredSigs); i++ {

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -745,65 +745,128 @@ func (c *Compiler) lowerCurrentOpcode() {
 			// Calculate the base address:
 			addr := builder.AllocateInstruction().AsIadd(c.getMemoryBaseValue(false), offset).Insert(builder).Return()
 
-			// Uses the copy trick for faster filling buffer, with a maximum chunk size of 8KB.
-			// https://github.com/golang/go/blob/go1.24.0/src/bytes/bytes.go#L664-L673
+			// Fill the region with inline 128-bit stores of the splat byte
+			// pattern: a 64-bytes-per-iteration main loop, a 16-byte loop for
+			// the remainder, and a byte tail. Large zero fills (the dominant
+			// case in practice: buffer clearing) are dispatched to the Go
+			// runtime's memclrNoHeapPointers, which uses the widest stores
+			// the platform has and non-temporal stores for very large sizes.
 			//
-			// 	buf := memoryInst.Buffer[offset : offset+fillSize]
-			// 	buf[0] = value
-			// 	for i := 1; i < fillSize; {
-			// 		chunk := ((i - 1) & 8191) + 1
-			// 		copy(buf[i:], buf[:chunk])
-			// 		i += chunk
+			// 	if fillSize >= 64 {
+			// 		if fillSize >= 1024 && (value&0xff) == 0 {
+			// 			memclr(addr, fillSize); goto done
+			// 		}
 			// 	}
+			// 	pattern := i8x16.splat(value)
+			// 	i := 0
+			// 	for ; i+64 <= fillSize; i += 64 { store128x4(addr+i, pattern) }
+			// 	for ; i+16 <= fillSize; i += 16 { store128(addr+i, pattern) }
+			// 	for ; i < fillSize; i++ { store8(addr+i, value) }
 
-			// Prepare the loop and following block.
-			beforeLoop := builder.AllocateBasicBlock()
-			loopBlk := builder.AllocateBasicBlock()
-			loopVar := loopBlk.AddParam(builder, ssa.TypeI64)
+			gateBlk := builder.AllocateBasicBlock()
+			memclrBlk := builder.AllocateBasicBlock()
+			mainLoopBlk := builder.AllocateBasicBlock()
+			mainLoopVar := mainLoopBlk.AddParam(builder, ssa.TypeI64)
+			midLoopBlk := builder.AllocateBasicBlock()
+			midLoopVar := midLoopBlk.AddParam(builder, ssa.TypeI64)
+			midBodyBlk := builder.AllocateBasicBlock()
+			tailLoopBlk := builder.AllocateBasicBlock()
+			tailLoopVar := tailLoopBlk.AddParam(builder, ssa.TypeI64)
+			tailBodyBlk := builder.AllocateBasicBlock()
 			followingBlk := builder.AllocateBasicBlock()
 
-			// Insert the jump to the beforeLoop block; If the fillSize is zero, then jump to the following block to skip entire logics.
+			// The 128-bit splat pattern, used by all inline store paths.
+			pattern := builder.AllocateInstruction().AsSplat(value, ssa.VecLaneI8x16).Insert(builder).Return()
+
 			zero := builder.AllocateInstruction().AsIconst64(0).Insert(builder).Return()
-			ifFillSizeZero := builder.AllocateInstruction().AsIcmp(fillSize, zero, ssa.IntegerCmpCondEqual).
-				Insert(builder).Return()
-			builder.AllocateInstruction().AsBrnz(ifFillSizeZero, ssa.ValuesNil, followingBlk).Insert(builder)
-			c.insertJumpToBlock(ssa.ValuesNil, beforeLoop)
+			sixtyFour := builder.AllocateInstruction().AsIconst64(64).Insert(builder).Return()
 
-			// buf[0] = value
-			builder.SetCurrentBlock(beforeLoop)
-			builder.AllocateInstruction().AsStore(ssa.OpcodeIstore8, value, addr, 0).Insert(builder)
-			one := builder.AllocateInstruction().AsIconst64(1).Insert(builder).Return()
-			c.insertJumpToBlock(c.allocateVarLengthValues(1, one), loopBlk)
-
-			builder.SetCurrentBlock(loopBlk)
-			dstAddr := builder.AllocateInstruction().AsIadd(addr, loopVar).Insert(builder).Return()
-
-			// chunk := ((i - 1) & 8191) + 1
-			mask := builder.AllocateInstruction().AsIconst64(8191).Insert(builder).Return()
-			tmp1 := builder.AllocateInstruction().AsIsub(loopVar, one).Insert(builder).Return()
-			tmp2 := builder.AllocateInstruction().AsBand(tmp1, mask).Insert(builder).Return()
-			chunk := builder.AllocateInstruction().AsIadd(tmp2, one).Insert(builder).Return()
-
-			// i += chunk
-			newLoopVar := builder.AllocateInstruction().AsIadd(loopVar, chunk).Insert(builder).Return()
-			newLoopVarLessThanFillSize := builder.AllocateInstruction().
-				AsIcmp(newLoopVar, fillSize, ssa.IntegerCmpCondUnsignedLessThan).Insert(builder).Return()
-
-			// count = min(chunk, fillSize-loopVar)
-			diff := builder.AllocateInstruction().AsIsub(fillSize, loopVar).Insert(builder).Return()
-			count := builder.AllocateInstruction().AsSelect(newLoopVarLessThanFillSize, chunk, diff).Insert(builder).Return()
-
-			c.callMemmove(dstAddr, addr, count)
-
+			// Small fills (including zero-length) go straight to the 16-byte
+			// loop, which falls through to the byte tail.
+			fillSizeLessThan64 := builder.AllocateInstruction().
+				AsIcmp(fillSize, sixtyFour, ssa.IntegerCmpCondUnsignedLessThan).Insert(builder).Return()
 			builder.AllocateInstruction().
-				AsBrnz(newLoopVarLessThanFillSize, c.allocateVarLengthValues(1, newLoopVar), loopBlk).
+				AsBrnz(fillSizeLessThan64, c.allocateVarLengthValues(1, zero), midLoopBlk).
 				Insert(builder)
+			c.insertJumpToBlock(ssa.ValuesNil, gateBlk)
 
+			// gate: large zero fills to memclr, everything else inline.
+			builder.SetCurrentBlock(gateBlk)
+			valueU64 := builder.AllocateInstruction().AsUExtend(value, 32, 64).Insert(builder).Return()
+			ff := builder.AllocateInstruction().AsIconst64(0xff).Insert(builder).Return()
+			valueByte := builder.AllocateInstruction().AsBand(valueU64, ff).Insert(builder).Return()
+			valueIsZero := builder.AllocateInstruction().
+				AsIcmp(valueByte, zero, ssa.IntegerCmpCondEqual).Insert(builder).Return()
+			kilo := builder.AllocateInstruction().AsIconst64(1024).Insert(builder).Return()
+			fillSizeBig := builder.AllocateInstruction().
+				AsIcmp(fillSize, kilo, ssa.IntegerCmpCondUnsignedGreaterThanOrEqual).Insert(builder).Return()
+			useMemclr := builder.AllocateInstruction().AsBand(valueIsZero, fillSizeBig).Insert(builder).Return()
+			builder.AllocateInstruction().
+				AsBrnz(useMemclr, ssa.ValuesNil, memclrBlk).
+				Insert(builder)
+			c.insertJumpToBlock(c.allocateVarLengthValues(1, zero), mainLoopBlk)
+
+			builder.SetCurrentBlock(memclrBlk)
+			c.callMemclr(addr, fillSize)
 			c.insertJumpToBlock(ssa.ValuesNil, followingBlk)
+
+			// Main loop: four 16-byte stores per iteration. Only entered
+			// while mainLoopVar+64 <= fillSize, so the stores stay within the
+			// bounds-checked region.
+			builder.SetCurrentBlock(mainLoopBlk)
+			mainDst := builder.AllocateInstruction().AsIadd(addr, mainLoopVar).Insert(builder).Return()
+			builder.AllocateInstruction().AsStore(ssa.OpcodeStore, pattern, mainDst, 0).Insert(builder)
+			builder.AllocateInstruction().AsStore(ssa.OpcodeStore, pattern, mainDst, 16).Insert(builder)
+			builder.AllocateInstruction().AsStore(ssa.OpcodeStore, pattern, mainDst, 32).Insert(builder)
+			builder.AllocateInstruction().AsStore(ssa.OpcodeStore, pattern, mainDst, 48).Insert(builder)
+			newMainLoopVar := builder.AllocateInstruction().AsIadd(mainLoopVar, sixtyFour).Insert(builder).Return()
+			nextMainCeil := builder.AllocateInstruction().AsIadd(newMainLoopVar, sixtyFour).Insert(builder).Return()
+			canContinueMain := builder.AllocateInstruction().
+				AsIcmp(nextMainCeil, fillSize, ssa.IntegerCmpCondUnsignedLessThanOrEqual).Insert(builder).Return()
+			builder.AllocateInstruction().
+				AsBrnz(canContinueMain, c.allocateVarLengthValues(1, newMainLoopVar), mainLoopBlk).
+				Insert(builder)
+			c.insertJumpToBlock(c.allocateVarLengthValues(1, newMainLoopVar), midLoopBlk)
+
+			// 16-byte loop header: run the body while midLoopVar+16 <= fillSize.
+			builder.SetCurrentBlock(midLoopBlk)
+			sixteen := builder.AllocateInstruction().AsIconst64(16).Insert(builder).Return()
+			midCeil := builder.AllocateInstruction().AsIadd(midLoopVar, sixteen).Insert(builder).Return()
+			midDone := builder.AllocateInstruction().
+				AsIcmp(midCeil, fillSize, ssa.IntegerCmpCondUnsignedGreaterThan).Insert(builder).Return()
+			builder.AllocateInstruction().
+				AsBrnz(midDone, c.allocateVarLengthValues(1, midLoopVar), tailLoopBlk).
+				Insert(builder)
+			c.insertJumpToBlock(ssa.ValuesNil, midBodyBlk)
+
+			builder.SetCurrentBlock(midBodyBlk)
+			midDst := builder.AllocateInstruction().AsIadd(addr, midLoopVar).Insert(builder).Return()
+			builder.AllocateInstruction().AsStore(ssa.OpcodeStore, pattern, midDst, 0).Insert(builder)
+			c.insertJumpToBlock(c.allocateVarLengthValues(1, midCeil), midLoopBlk)
+
+			// Byte tail loop header: exit when tailLoopVar reaches fillSize.
+			builder.SetCurrentBlock(tailLoopBlk)
+			tailDone := builder.AllocateInstruction().
+				AsIcmp(tailLoopVar, fillSize, ssa.IntegerCmpCondUnsignedGreaterThanOrEqual).Insert(builder).Return()
+			builder.AllocateInstruction().AsBrnz(tailDone, ssa.ValuesNil, followingBlk).Insert(builder)
+			c.insertJumpToBlock(ssa.ValuesNil, tailBodyBlk)
+
+			builder.SetCurrentBlock(tailBodyBlk)
+			tailDst := builder.AllocateInstruction().AsIadd(addr, tailLoopVar).Insert(builder).Return()
+			builder.AllocateInstruction().AsStore(ssa.OpcodeIstore8, value, tailDst, 0).Insert(builder)
+			one := builder.AllocateInstruction().AsIconst64(1).Insert(builder).Return()
+			newTailLoopVar := builder.AllocateInstruction().AsIadd(tailLoopVar, one).Insert(builder).Return()
+			c.insertJumpToBlock(c.allocateVarLengthValues(1, newTailLoopVar), tailLoopBlk)
+
 			builder.SetCurrentBlock(followingBlk)
 
-			builder.Seal(beforeLoop)
-			builder.Seal(loopBlk)
+			builder.Seal(gateBlk)
+			builder.Seal(memclrBlk)
+			builder.Seal(mainLoopBlk)
+			builder.Seal(midLoopBlk)
+			builder.Seal(midBodyBlk)
+			builder.Seal(tailLoopBlk)
+			builder.Seal(tailBodyBlk)
 			builder.Seal(followingBlk)
 
 		case wasm.OpcodeMiscMemoryInit:
@@ -4376,6 +4439,20 @@ func (c *Compiler) callMemmove(dst, src, size ssa.Value) {
 			ssa.TypeI64,
 		).Insert(builder).Return()
 	builder.AllocateInstruction().AsCallGoRuntimeMemmove(memmovePtr, &c.memmoveSig, args).Insert(builder)
+}
+
+// callMemclr emits a call to the Go runtime's memclrNoHeapPointers through
+// the same mechanism as callMemmove (the isMemmove call handling also covers
+// memclr: both may clobber every vector register).
+func (c *Compiler) callMemclr(ptr, size ssa.Value) {
+	args := c.allocateVarLengthValues(2, ptr, size)
+	builder := c.ssaBuilder
+	memclrPtr := builder.AllocateInstruction().
+		AsLoad(c.execCtxPtrValue,
+			wazevoapi.ExecutionContextOffsetMemclrAddress.U32(),
+			ssa.TypeI64,
+		).Insert(builder).Return()
+	builder.AllocateInstruction().AsCallGoRuntimeMemmove(memclrPtr, &c.memclrSig, args).Insert(builder)
 }
 
 func (c *Compiler) reloadAfterCall() {

--- a/internal/engine/wazevo/memclr.go
+++ b/internal/engine/wazevo/memclr.go
@@ -1,0 +1,17 @@
+package wazevo
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// memclrNoHeapPointers is the Go runtime's optimized memory-clearing
+// routine (wide SIMD stores, and non-temporal stores for very large sizes).
+// Like memmove above, it is safe to call directly from generated code: it is
+// nosplit, allocation-free, and touches no pointers the GC cares about.
+// Used as a fast path for memory.fill with a zero value.
+//
+//go:linkname memclrNoHeapPointers runtime.memclrNoHeapPointers
+func memclrNoHeapPointers(_ unsafe.Pointer, _ uintptr)
+
+var memclrPtr = reflect.ValueOf(memclrNoHeapPointers).Pointer()

--- a/internal/engine/wazevo/module_engine.go
+++ b/internal/engine/wazevo/module_engine.go
@@ -221,6 +221,7 @@ func (m *moduleEngine) NewFunction(index wasm.Index) api.Function {
 	ce.execCtx.tryTableEnterTrampolineAddress = sharedFunctions.tryTableEnterAddress
 	ce.execCtx.tryTableLeaveTrampolineAddress = sharedFunctions.tryTableLeaveAddress
 	ce.execCtx.memmoveAddress = memmovPtr
+	ce.execCtx.memclrAddress = memclrPtr
 	ce.init()
 	return ce
 }

--- a/internal/engine/wazevo/wazevoapi/offsetdata.go
+++ b/internal/engine/wazevo/wazevoapi/offsetdata.go
@@ -74,6 +74,8 @@ const (
 	// where locals are mirrored inside try_table bodies, so that handler blocks
 	// can read throw-time local values after stack-clone restore.
 	ExecutionContextOffsetLocalsSaveAreaPtr Offset = 1240
+	// ExecutionContextOffsetMemclrAddress is the offset of `memclrAddress` in executionContext.
+	ExecutionContextOffsetMemclrAddress Offset = 1248
 )
 
 // ModuleContextOffsetData allows the compilers to get the information about offsets to the fields of wazevo.moduleContextOpaque,


### PR DESCRIPTION
Improved version of #2528

## Design

### Problem

Upstream lowers `memory.fill` with the copy-doubling trick: write one byte, then `memory.copy` doubling chunks (≤8 KB) via calls to `runtime.memmove`. That makes a fill issue **2× the memory traffic** (every chunk is re-read as the source of the next copy) plus a call per chunk. PDFium clears multi-megabyte bitmap buffers through this path on every render.

### Change

Two mechanisms, dispatched by size and value:

**1. Inline 128-bit store loops.** The fill value is broadcast with a single `i8x16.splat` (one `dup v.16b` on arm64 — simpler than the previous scalar `×0x0101010101010101` multiply trick), then:
- a **64 bytes/iteration** main loop of four 128-bit stores,
- a 16-byte loop for the remainder,
- a byte tail (<16 bytes).

128-bit stores double fill bandwidth over 8-byte stores on cores that sustain two stores per cycle regardless of width (all Apple M-series, most modern x86). All stores stay within the already-bounds-checked region.

**2. memclr fast path for large zero fills.** Fills that are **≥ 1 KiB and zero-valued** call `runtime.memclrNoHeapPointers` directly. Zero is the dominant fill value in practice — `memory.fill` overwhelmingly comes from `memset(p, 0, n)` buffer clears and from language runtimes zeroing allocations (TinyGo's allocator, for example, which is exactly why the matmul benchmarks below move). memclr is the best fill code on every platform: widest available stores and non-temporal stores for very large sizes, which no inline JIT loop can emit. The call reuses the **exact mechanism** the existing `memory.copy` lowering uses for `runtime.memmove` (a linknamed address in the execution context, invoked via the same call instruction) — and that call path's special handling, releasing all vector registers at the call site, is precisely what memclr also requires. The 1 KiB threshold keeps small zero fills (ubiquitous in C/C++ guest code: struct zero-init) on the inline loop, so they never pay call overhead.

Dispatch shape in the generated code: fills < 64 B skip straight to the 16-byte/byte loops; fills ≥ 64 B check `(value & 0xff) == 0 && size >= 1024` once (a single fused test) and go to memclr or the main loop.

### Why this is safe

`memclrNoHeapPointers` has the same "callable from generated code" properties as `runtime.memmove`, which wazevo already links and calls the same way: nosplit, allocation-free, no GC-visible pointer writes. The bounds check runs before any dispatch, unchanged.

## Correctness

- Full spectest matrix (v1, v2, exception-handling, threads, tail-call, typed-function-references, extended-const) and `integration_test/engine` pass on arm64; v1+v2+engine verified on amd64 (Rosetta) — `memory_fill.wast` exercises the memclr, main-loop, mid-loop, and tail paths on both ISAs.
- `-race` passes on spectest v2.
- The go-pdfium golden-hash corpora (32 verified render outputs + the EH corpus) are pixel-identical.

## Measured performance (Apple M5, arm64; benchstat n=6, three legs interleaved per pass; base = main @ ab01134c)

### PDF rendering (go-pdfium: PDFium-as-wasm, open + render at 200 DPI + close)

vs **main**: geomean **−12.9%**. vs **perf/memory-fill-inline**: geomean **−9.9%** — the SIMD+memclr version wins everywhere:

```
                          main          fill-inline   fill-simd     vs main   vs inline
building_plan.pdf         3.021m ± 2%   2.583m ± 1%   1.997m ± 1%   -33.91%   -22.70%
test.pdf                  1.312m ± 2%   1.245m ± 1%   933.4µ ± 1%   -28.85%   -25.01%
invoice B                 5.890m ± 2%   5.786m ± 7%   5.407m ± 2%    -8.20%    -6.54%
alpha_channel.pdf         89.95m ± 2%   86.94m ± 2%   83.39m ± 1%    -7.30%    -4.09%
invoice A                 9.322m ± 2%   9.147m ± 0%   8.745m ± 1%    -6.19%    -4.40%
image_page.pdf           100.69m ± 3%  100.81m ± 1%   96.29m ± 2%    -4.37%    -4.49%
mona.pdf                  546.8µ ±50%   546.6µ ± 1%   524.3µ ± 1%    -4.11%    -4.07%
rect-wrong.pdf            28.95m ± 2%   29.24m ± 3%   27.80m ± 1%    -3.95%    -4.91%
geomean                   8.645m        8.359m        7.528m        -12.92%    -9.94%
```

(All rows p=0.002. The fill-heavy documents — building_plan, test.pdf — are dominated by large bitmap clears; the memclr path carries most of their win.)

### wazero's own benchmark suite (`BenchmarkInvocation/compiler`)

Geomean **−6.3%** vs main, no regressions:

```
random_mat_mul_size_20    47.96µ → 36.30µ   -24.30% (p=0.002)
random_mat_mul_size_10   10.961µ →  7.882µ  -28.09% (p=0.002)
string_manipulation_50    7.372µ →  6.755µ   -8.38% (p=0.002)
string_manipulation_100   23.12µ → 21.96µ    -4.99% (p=0.002)
base64 / fib / reverse_array        (all ~, p>0.05)
geomean                   19.89µ → 18.64µ    -6.25%
```

(The matmul rows are TinyGo-compiled Go: its allocator zeroes new blocks through `memory.fill`, which now hits the memclr path.)

### Zig stdlib suite (`internal/integration_test/stdlibs`, Zig 0.11.0)

Neutral, as expected — the Zig test binaries are not fill-bound (every row n.s., p ≥ 0.39):

```
                     main         fill-simd
Zig/Compile/test-opt  1.732 ± 2%   1.736 ± 1%   ~
Zig/Run/test-opt      11.18 ± 1%   11.19 ± 1%   ~
Zig/Compile/test      2.064 ± 1%   2.065 ± 1%   ~
Zig/Run/test          11.55 ± 1%   11.52 ± 2%   ~
geomean               4.635        4.637        +0.04%
```

(vs `perf/memory-fill-inline`: likewise all n.s., geomean +0.16%.)

## Notes for review

- The memclr threshold (1 KiB) is deliberately conservative: below it the inline loop's ~2–10 ns beats or matches any call; above it memclr's wide/non-temporal stores win and the call overhead is noise. Happy to tune with data if reviewers prefer a different split.
- If taking a dependency on `runtime.memclrNoHeapPointers` via linkname is unwanted despite the `runtime.memmove` precedent, the memclr commit can be dropped and the inline-SIMD part stands alone (still −4 to −5% on most documents vs the scalar inline loop, and strictly better than copy-doubling).
- `i8x16.splat` + 128-bit stores lower cleanly on both ISAs today (`dup`+`str q` / `movdqu`); no backend changes were needed — the only backend-adjacent fact used is that the `memory.copy` call path already releases vector registers.