### PR TITLE
poll_oneoff: do not sleep when there is no clock subscription

### DIFF
--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -89,8 +89,8 @@ func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) sys.Errno 
 		file sys.File
 	}
 	// The timeout is initialized at max Duration, the loop will find the minimum.
-	var timeout time.Duration = 1<<63 - 1
-	hasClockSub := false
+	const noTimeout = time.Duration(1<<63 - 1)
+	timeout := noTimeout
 	// Count of all the subscriptions that have been already written back to outBuf.
 	// nevents*32 returns at all times the offset where the next event should be written:
 	// this way we ensure that there are no gaps between records.
@@ -123,7 +123,6 @@ func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) sys.Errno 
 			if newTimeout < timeout {
 				timeout = newTimeout
 			}
-			hasClockSub = true
 			// Ack the clock event to the outBuf.
 			writeEvent(outBuf[outOffset:], evt)
 			nevents++
@@ -170,7 +169,7 @@ func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) sys.Errno 
 		// earlier to offset `resultNevents`.
 		// We only need to observe the timeout (lowered only by clock subscriptions)
 		// and return.
-		if hasClockSub && timeout > 0 {
+		if timeout != noTimeout && timeout > 0 {
 			sysCtx.Nanosleep(int64(timeout))
 		}
 		return 0

--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -90,6 +90,7 @@ func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) sys.Errno 
 	}
 	// The timeout is initialized at max Duration, the loop will find the minimum.
 	var timeout time.Duration = 1<<63 - 1
+	hasClockSub := false
 	// Count of all the subscriptions that have been already written back to outBuf.
 	// nevents*32 returns at all times the offset where the next event should be written:
 	// this way we ensure that there are no gaps between records.
@@ -122,6 +123,7 @@ func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) sys.Errno 
 			if newTimeout < timeout {
 				timeout = newTimeout
 			}
+			hasClockSub = true
 			// Ack the clock event to the outBuf.
 			writeEvent(outBuf[outOffset:], evt)
 			nevents++
@@ -166,9 +168,9 @@ func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) sys.Errno 
 	if nevents == nsubscriptions {
 		// We already wrote back all the results. We already wrote this number
 		// earlier to offset `resultNevents`.
-		// We only need to observe the timeout (nonzero if there are clock subscriptions)
+		// We only need to observe the timeout (lowered only by clock subscriptions)
 		// and return.
-		if timeout > 0 {
+		if hasClockSub && timeout > 0 {
 			sysCtx.Nanosleep(int64(timeout))
 		}
 		return 0

--- a/imports/wasi_snapshot_preview1/poll_test.go
+++ b/imports/wasi_snapshot_preview1/poll_test.go
@@ -63,6 +63,37 @@ func Test_pollOneoff(t *testing.T) {
 	require.Equal(t, nsubscriptions, nevents)
 }
 
+// Test_pollOneoff_NoClockSubscription verifies that a subscription list with no
+// clock subscription returns instead of sleeping on the sentinel timeout:
+// wasi-libc emits no clock subscription for poll(fds, nfds, -1).
+func Test_pollOneoff_NoClockSubscription(t *testing.T) {
+	var slept []int64
+	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().
+		WithNanosleep(func(ns int64) { slept = append(slept, ns) }))
+	defer r.Close(testCtx)
+
+	in := uint32(0)    // past in
+	out := uint32(128) // past in
+	nsubscriptions := uint32(1)
+	resultNevents := uint32(512) // past out
+
+	maskMemory(t, mod, 1024)
+	mod.Memory().Write(in, fdWriteSubFd(byte(sys.FdStdout)))
+
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.PollOneoffName, uint64(in), uint64(out),
+		uint64(nsubscriptions), uint64(resultNevents))
+	require.Equal(t, `
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1)
+<== (nevents=1,errno=ESUCCESS)
+`, "\n"+log.String())
+
+	nevents, ok := mod.Memory().ReadUint32Le(resultNevents)
+	require.True(t, ok)
+	require.Equal(t, nsubscriptions, nevents)
+
+	require.Zero(t, len(slept))
+}
+
 func Test_pollOneoff_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig())
 	defer r.Close(testCtx)
@@ -887,4 +918,16 @@ func (p *pollableFile) Poll(flag experimentalsys.Pflag, timeoutMillis int32) (re
 		time.Sleep(p.sleep)
 	}
 	return p.ready, p.errno
+}
+
+func fdWriteSubFd(fd byte) []byte {
+	return []byte{
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // userdata
+		wasip1.EventTypeFdWrite, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		fd, 0x0, 0x0, 0x0, // valid writable FD
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, // pad to 32 bytes
+	}
 }


### PR DESCRIPTION
`wazero run` never comes back from a guest that calls `poll(fds, nfds, -1)` on a writable fd. The events do get written back and nevents is right. Then it parks in `Nanosleep` for 9223372036854775807ns, which is about 292 years.

`timeout` starts at max Duration so the loop can take the minimum, and only a clock subscription ever lowers it. wasi-libc adds that subscription inside `if (timeout)` ([ppoll.c](https://github.com/WebAssembly/wasi-libc/blob/main/libc-bottom-half/sources/ppoll.c)), so a poll with an infinite timeout sends a list with no clock event in it, and the sentinel makes it all the way to the sleep.

The comment above that sleep already says the timeout is nonzero if there are clock subscriptions, so this is mostly just making that true.

The test passes its own `Nanosleep` in beacuse the default one is a no-op. Nothing in the suite ever saw the argument.

---

Somthing adjacent I've left alone: with a clock subscription and an fd_write subscription together, the fd_write event gets acked straight away but the whole clock timeout still gets slept. Could well be deliberate, and I didnt want to change it in here.
