### PR TITLE
Add a read-only compilation cache that requires guest cache hits

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -59,12 +59,48 @@ func NewCompilationCacheWithDir(dirname string) (CompilationCache, error) {
 	return c, err
 }
 
+// Compilation cache errors can be classified with errors.Is.
+var (
+	// ErrCompilationCacheMiss indicates that a required entry is absent.
+	ErrCompilationCacheMiss = filecache.ErrMiss
+	// ErrCompilationCacheStale indicates an incompatible entry.
+	ErrCompilationCacheStale = filecache.ErrStale
+	// ErrCompilationCacheCorrupt indicates that an entry could not be decoded.
+	ErrCompilationCacheCorrupt = filecache.ErrCorrupt
+	// ErrCompilationCacheIO indicates a directory or entry access failure.
+	ErrCompilationCacheIO = filecache.ErrIO
+	// ErrCompilationCacheUnsupported indicates an engine without persistent cache support.
+	ErrCompilationCacheUnsupported = filecache.ErrUnsupported
+)
+
+// NewCompilationCacheWithDirReadOnly opens an existing persistent compilation cache.
+// Both dirname and its version/OS/architecture subdirectory must already exist.
+// Unlike NewCompilationCacheWithDir, this never creates, writes, or deletes files.
+// Guest modules must hit the in-memory or persistent cache: missing, stale, or
+// corrupt entries return classifiable errors without compiling the guest module.
+// The interpreter (including automatic fallback on unsupported platforms) rejects
+// guest modules with ErrCompilationCacheUnsupported. Host modules are permitted.
+//
+// This is not a zero-code-generation mode: shared/host trampolines and bounded
+// per-type entry preambles for cache hits can still be generated.
+// Cache entries are trusted executable input, not a safe untrusted format. The
+// embedder must protect the directory and use the same wazero version, CPU
+// features, and compilation configuration when warming and reading the cache.
+func NewCompilationCacheWithDirReadOnly(dirname string) (CompilationCache, error) {
+	c := &cache{readOnly: true}
+	if err := c.ensuresFileCache(dirname, version.GetWazeroVersion()); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCompilationCacheIO, err)
+	}
+	return c, nil
+}
+
 // cache implements Cache interface.
 type cache struct {
 	// eng is the engine for this cache. If the cache is configured, the engine is shared across multiple instances of
 	// Runtime, and its lifetime is not bound to them. Instead, the engine is alive until Cache.Close is called.
 	engs      [engineKindCount]wasm.Engine
 	fileCache filecache.Cache
+	readOnly  bool
 	initOnces [engineKindCount]sync.Once
 }
 
@@ -93,18 +129,26 @@ func (c *cache) ensuresFileCache(dir string, wazeroVersion string) error {
 		return err
 	}
 
+	ensureDir := mkdir
+	if c.readOnly {
+		ensureDir = existingDir
+	}
 	// Ensure the user-supplied directory.
-	if err = mkdir(dir); err != nil {
+	if err = ensureDir(dir); err != nil {
 		return err
 	}
 
 	// Create a version-specific directory to avoid conflicts.
 	dirname := path.Join(dir, "wazero-"+wazeroVersion+"-"+goruntime.GOARCH+"-"+goruntime.GOOS)
-	if err = mkdir(dirname); err != nil {
+	if err = ensureDir(dirname); err != nil {
 		return err
 	}
 
-	c.fileCache = filecache.New(dirname)
+	if c.readOnly {
+		c.fileCache = filecache.NewReadOnly(dirname)
+	} else {
+		c.fileCache = filecache.New(dirname)
+	}
 	return nil
 }
 
@@ -117,6 +161,17 @@ func mkdir(dirname string) error {
 	} else if err != nil {
 		return err
 	} else if !st.IsDir() {
+		return fmt.Errorf("%s is not dir", dirname)
+	}
+	return nil
+}
+
+func existingDir(dirname string) error {
+	st, err := os.Stat(dirname)
+	if err != nil {
+		return err
+	}
+	if !st.IsDir() {
 		return fmt.Errorf("%s is not dir", dirname)
 	}
 	return nil

--- a/cache_readonly_test.go
+++ b/cache_readonly_test.go
@@ -1,0 +1,130 @@
+package wazero
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/version"
+)
+
+func TestCompilationCacheReadOnlyDirectories(t *testing.T) {
+	for _, kind := range []string{"missing root", "missing version", "root file", "version file"} {
+		t.Run(kind, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), "cache")
+			switch kind {
+			case "missing version", "version file":
+				require.NoError(t, os.Mkdir(root, 0o700))
+			case "root file":
+				require.NoError(t, os.WriteFile(root, nil, 0o600))
+			}
+			versionDir := filepath.Join(root, "wazero-"+version.GetWazeroVersion()+"-"+goruntime.GOARCH+"-"+goruntime.GOOS)
+			if kind == "version file" {
+				require.NoError(t, os.WriteFile(versionDir, nil, 0o600))
+			}
+			c, err := NewCompilationCacheWithDirReadOnly(root)
+			require.Nil(t, c)
+			require.True(t, errors.Is(err, ErrCompilationCacheIO))
+			if kind == "missing root" {
+				_, err = os.Stat(root)
+				require.True(t, os.IsNotExist(err))
+			}
+			if kind == "missing version" {
+				entries, err := os.ReadDir(root)
+				require.NoError(t, err)
+				require.Equal(t, 0, len(entries))
+			}
+		})
+	}
+}
+
+func TestCompilationCacheReadOnly(t *testing.T) {
+	if !platform.CompilerSupported() {
+		t.Skip("persistent compiler cache unsupported")
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	warm, err := NewCompilationCacheWithDir(dir)
+	require.NoError(t, err)
+	r := NewRuntimeWithConfig(ctx, NewRuntimeConfigCompiler().WithCompilationCache(warm))
+	compiled, err := r.CompileModule(ctx, facWasm)
+	require.NoError(t, err)
+	require.NoError(t, compiled.Close(ctx))
+	require.NoError(t, r.Close(ctx))
+	require.NoError(t, warm.Close(ctx))
+	before := cacheDirectorySnapshot(t, dir)
+	// Each iteration starts with a fresh cache engine, not just a fresh runtime.
+	for i := 0; i < 2; i++ {
+		c, err := NewCompilationCacheWithDirReadOnly(dir)
+		require.NoError(t, err)
+		r = NewRuntimeWithConfig(ctx, NewRuntimeConfigCompiler().WithCompilationCache(c))
+		m, err := r.Instantiate(ctx, facWasm)
+		require.NoError(t, err)
+		result, err := m.ExportedFunction("fac-ssa").Call(ctx, 5)
+		require.NoError(t, err)
+		require.Equal(t, []uint64{120}, result)
+		_, err = r.CompileModule(ctx, memGrowWasm)
+		require.True(t, errors.Is(err, ErrCompilationCacheMiss))
+		_, err = r.NewHostModuleBuilder("host").NewFunctionBuilder().WithFunc(func() {}).Export("f").Instantiate(ctx)
+		require.NoError(t, err)
+		require.NoError(t, r.Close(ctx))
+		require.NoError(t, c.Close(ctx))
+		require.Equal(t, before, cacheDirectorySnapshot(t, dir))
+	}
+	// The default constructor still compiles and writes a miss.
+	rw, err := NewCompilationCacheWithDir(dir)
+	require.NoError(t, err)
+	r = NewRuntimeWithConfig(ctx, NewRuntimeConfigCompiler().WithCompilationCache(rw))
+	_, err = r.CompileModule(ctx, memGrowWasm)
+	require.NoError(t, err)
+	require.NoError(t, r.Close(ctx))
+	require.NoError(t, rw.Close(ctx))
+	require.True(t, len(cacheDirectorySnapshot(t, dir)) > len(before))
+}
+
+func TestCompilationCacheReadOnlyInterpreter(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	warm, err := NewCompilationCacheWithDir(dir)
+	require.NoError(t, err)
+	require.NoError(t, warm.Close(ctx))
+	c, err := NewCompilationCacheWithDirReadOnly(dir)
+	require.NoError(t, err)
+	defer c.Close(ctx)
+	configs := []RuntimeConfig{NewRuntimeConfigInterpreter()}
+	if !platform.CompilerSupported() {
+		configs = append(configs, NewRuntimeConfig())
+	}
+	for _, config := range configs {
+		r := NewRuntimeWithConfig(ctx, config.WithCompilationCache(c))
+		_, err = r.CompileModule(ctx, facWasm)
+		require.True(t, errors.Is(err, ErrCompilationCacheUnsupported))
+		_, err = r.NewHostModuleBuilder("host").NewFunctionBuilder().WithFunc(func() {}).Export("f").Instantiate(ctx)
+		require.NoError(t, err)
+		require.NoError(t, r.Close(ctx))
+	}
+}
+
+func cacheDirectorySnapshot(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	snapshot := map[string]string{}
+	require.NoError(t, filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			data, err := os.ReadFile(p)
+			if err != nil {
+				return err
+			}
+			snapshot[p] = string(data) + info.ModTime().String() + info.Mode().String()
+		}
+		return nil
+	}))
+	return snapshot
+}

--- a/config.go
+++ b/config.go
@@ -134,6 +134,8 @@ type RuntimeConfig interface {
 	// version of wazero due to the known issue of debug.BuildInfo function: https://github.com/golang/go/issues/33976.
 	// As a consequence, your cache won't contain the correct version information and always be treated as `dev` version.
 	// To avoid this issue, you can pass -ldflags "-X github.com/tetratelabs/wazero/internal/version.version=foo" when running tests.
+	// NewCompilationCacheWithDirReadOnly requires hits and rejects guest compilation
+	// on interpreter runtimes, including automatic fallback on unsupported platforms.
 	WithCompilationCache(CompilationCache) RuntimeConfig
 
 	// WithCustomSections toggles parsing of "custom sections". Defaults to false.

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -35,14 +35,16 @@ type compiledFunctionWithCount struct {
 
 // engine is an interpreter implementation of wasm.Engine
 type engine struct {
+	requireCacheHit   bool
 	enabledFeatures   api.CoreFeatures
 	compiledFunctions map[wasm.ModuleID]*compiledFunctionWithCount // guarded by mutex.
 	mux               sync.Mutex
 }
 
-func NewEngine(_ context.Context, enabledFeatures api.CoreFeatures, _ filecache.Cache) wasm.Engine {
+func NewEngine(_ context.Context, enabledFeatures api.CoreFeatures, fc filecache.Cache) wasm.Engine {
 	return &engine{
 		enabledFeatures:   enabledFeatures,
+		requireCacheHit:   filecache.ReadOnly(fc),
 		compiledFunctions: map[wasm.ModuleID]*compiledFunctionWithCount{},
 	}
 }
@@ -505,6 +507,9 @@ const callFrameStackSize = 0
 
 // CompileModule implements the same method as documented on wasm.Engine.
 func (e *engine) CompileModule(_ context.Context, module *wasm.Module, listeners []experimental.FunctionListener, ensureTermination bool) error {
+	if e.requireCacheHit && !module.IsHostModule {
+		return filecache.ErrUnsupported
+	}
 	if _, ok := e.getCompiledFunctions(module, true); ok { // cache hit!
 		return nil
 	}

--- a/internal/engine/wazevo/engine_cache.go
+++ b/internal/engine/wazevo/engine_cache.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -113,7 +114,7 @@ func (e *engine) getCompiledModuleFromMemory(module *wasm.Module, increaseRefCou
 }
 
 func (e *engine) addCompiledModuleToCache(module *wasm.Module, cm *compiledModule) (err error) {
-	if e.fileCache == nil || module.IsHostModule {
+	if e.fileCache == nil || module.IsHostModule || filecache.ReadOnly(e.fileCache) {
 		return
 	}
 	err = e.fileCache.Add(fileCacheKey(module), serializeCompiledModule(e.wazeroVersion, cm))
@@ -129,6 +130,9 @@ func (e *engine) getCompiledModuleFromCache(module *wasm.Module) (cm *compiledMo
 	var cached io.ReadCloser
 	cached, hit, err = e.fileCache.Get(fileCacheKey(module))
 	if !hit || err != nil {
+		if filecache.ReadOnly(e.fileCache) && err == nil {
+			err = filecache.ErrMiss
+		}
 		return
 	}
 
@@ -138,9 +142,15 @@ func (e *engine) getCompiledModuleFromCache(module *wasm.Module) (cm *compiledMo
 	// Note: cached.Close is ensured to be called in deserializeCodes.
 	cm, staleCache, err = deserializeCompiledModule(e.wazeroVersion, cached)
 	if err != nil {
+		if filecache.ReadOnly(e.fileCache) && !errors.Is(err, filecache.ErrIO) {
+			err = fmt.Errorf("%w: %w", filecache.ErrCorrupt, err)
+		}
 		hit = false
 		return
 	} else if staleCache {
+		if filecache.ReadOnly(e.fileCache) {
+			return nil, false, filecache.ErrStale
+		}
 		return nil, false, e.fileCache.Delete(fileCacheKey(module))
 	}
 	return
@@ -202,8 +212,42 @@ func serializeCompiledModule(wazeroVersion string, cm *compiledModule) io.Reader
 	return bytes.NewReader(buf.Bytes())
 }
 
-func deserializeCompiledModule(wazeroVersion string, reader io.ReadCloser) (cm *compiledModule, staleCache bool, err error) {
+// cacheIOReader distinguishes storage failures from ordinary EOF/truncation.
+// Recording the failure also covers readers that return data and an error together.
+type cacheIOReader struct {
+	io.ReadCloser
+	err error
+}
+
+func (r *cacheIOReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if r.err == nil && err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		r.err = err
+	}
+	return n, err
+}
+
+func deserializeCompiledModule(wazeroVersion string, reader io.ReadCloser) (*compiledModule, bool, error) {
+	return deserializeCompiledModuleWithUnmap(wazeroVersion, reader, platform.MunmapCodeSegment)
+}
+
+// The unmap parameter lets tests verify ownership on every unsuccessful load.
+func deserializeCompiledModuleWithUnmap(wazeroVersion string, reader io.ReadCloser, unmap func([]byte) error) (cm *compiledModule, staleCache bool, err error) {
+	reads := &cacheIOReader{ReadCloser: reader}
+	reader = reads
 	defer reader.Close()
+	var mapped []byte
+	defer func() {
+		if reads.err != nil {
+			cm, staleCache = nil, false
+			err = errors.Join(fmt.Errorf("%w: %w", filecache.ErrIO, reads.err), err)
+		}
+		if len(mapped) > 0 && (err != nil || staleCache) {
+			if unmapErr := unmap(mapped); unmapErr != nil {
+				err = errors.Join(err, fmt.Errorf("compilationcache: unmap failed: %w", unmapErr))
+			}
+		}
+	}()
 	cacheHeaderSize := len(magic) + 1 /* version size */ + len(wazeroVersion) + 4 /* number of functions */
 
 	// Read the header before the native code.
@@ -261,6 +305,7 @@ func deserializeCompiledModule(wazeroVersion string, reader io.ReadCloser) (cm *
 			return nil, false, err
 		}
 
+		mapped = executable
 		_, err = io.ReadFull(reader, executable)
 		if err != nil {
 			err = fmt.Errorf("compilationcache: error reading executable (len=%d): %v", executableLen, err)
@@ -280,11 +325,25 @@ func deserializeCompiledModule(wazeroVersion string, reader io.ReadCloser) (cm *
 		cm.executable = executable
 	}
 
+	if executableLen == 0 {
+		if _, err = io.ReadFull(reader, eightBytes[:4]); err != nil {
+			return nil, false, fmt.Errorf("compilationcache: could not read checksum: %v", err)
+		}
+		if binary.LittleEndian.Uint32(eightBytes[:4]) != 0 {
+			return nil, false, fmt.Errorf("compilationcache: nonzero checksum for empty executable")
+		}
+	}
 	if _, err := io.ReadFull(reader, eightBytes[:1]); err != nil {
 		return nil, false, fmt.Errorf("compilationcache: error reading source map presence: %v", err)
 	}
 
+	if eightBytes[0] > 1 {
+		return nil, false, fmt.Errorf("compilationcache: invalid source map presence")
+	}
 	if eightBytes[0] == 1 {
+		if len(cm.executable) == 0 {
+			return nil, false, fmt.Errorf("compilationcache: source map without executable")
+		}
 		sm := &cm.sourceMap
 		sourceMapLen, err := readUint64(reader, &eightBytes)
 		if err != nil {

--- a/internal/engine/wazevo/engine_cache_readonly_test.go
+++ b/internal/engine/wazevo/engine_cache_readonly_test.go
@@ -1,0 +1,222 @@
+package wazevo
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"unsafe"
+
+	"github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi"
+	"github.com/tetratelabs/wazero/internal/filecache"
+	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
+)
+
+func TestReadOnlyCacheStopsBeforeGuestCompilation(t *testing.T) {
+	// This deliberately incomplete module panics if the guest compiler is entered.
+	// No compiler machinery is initialized in the engine below.
+	module := &wasm.Module{FunctionSection: []wasm.Index{0}, CodeSection: []wasm.Code{{Body: []byte{0xff}}}}
+	t.Run("compiler poison is effective", func(t *testing.T) {
+		defer func() { require.True(t, recover() != nil) }()
+		_, _ = (&engine{}).compileModule(context.Background(), module, nil, false)
+	})
+	encoded, err := io.ReadAll(serializeCompiledModule(testVersion, &compiledModule{
+		executables: &executables{executable: []byte{1, 2, 3, 4}}, functionOffsets: []int{0},
+	}))
+	require.NoError(t, err)
+	badChecksum := bytes.Clone(encoded)
+	badChecksum[len(encoded)-9] ^= 0xff
+	for _, tc := range []struct {
+		name string
+		data []byte
+		want error
+	}{
+		{"missing", nil, filecache.ErrMiss},
+		{"stale", concat(magic, []byte{byte(len(testVersion))}, []byte("9.9.9"), make([]byte, 4)), filecache.ErrStale},
+		{"corrupt", []byte("broken"), filecache.ErrCorrupt},
+		{"stale after mmap", encoded[:len(encoded)-4], filecache.ErrStale},
+		{"checksum after mmap", badChecksum, filecache.ErrCorrupt},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			rw := filecache.New(dir)
+			if tc.data != nil {
+				require.NoError(t, rw.Add(fileCacheKey(module), bytes.NewReader(tc.data)))
+			}
+			before := snapshotCacheFiles(t, dir)
+			e := &engine{fileCache: filecache.NewReadOnly(dir), wazeroVersion: testVersion}
+			err := e.CompileModule(context.Background(), module, nil, false)
+			require.True(t, errors.Is(err, tc.want), err)
+			require.Equal(t, before, snapshotCacheFiles(t, dir))
+			require.Equal(t, 0, len(e.compiledModules))
+		})
+	}
+}
+
+func snapshotCacheFiles(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	ret := map[string]string{}
+	for _, entry := range entries {
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		require.NoError(t, err)
+		info, err := entry.Info()
+		require.NoError(t, err)
+		ret[entry.Name()] = string(data) + info.ModTime().String() + info.Mode().String()
+	}
+	return ret
+}
+
+func TestDeserializeCompiledModuleReleasesMapping(t *testing.T) {
+	executable := []byte{1, 2, 3, 4}
+	cm := &compiledModule{
+		executables:     &executables{executable: executable},
+		functionOffsets: []int{0},
+		sourceMap: sourceMap{
+			executableOffsets: []uintptr{uintptr(unsafe.Pointer(&executable[0]))},
+			wasmBinaryOffsets: []uint64{0},
+		},
+		tryTableInfo: []wazevoapi.TryTableInfo{{
+			NumLocals:    1,
+			ReuseLocals:  true,
+			CatchClauses: []wazevoapi.CatchClauseInstance{{Kind: 0, TagIndex: 0}},
+		}},
+	}
+	data, err := io.ReadAll(serializeCompiledModule(testVersion, cm))
+	require.NoError(t, err)
+	// Every truncation after the mapping is allocated must unmap exactly once,
+	// including the stale old-format path with no try-table data.
+	codeStart := len(magic) + 1 + len(testVersion) + 4 + 8 + 8
+	for end := codeStart; end < len(data); end++ {
+		t.Run(strconv.Itoa(end-codeStart), func(t *testing.T) {
+			unmapped := 0
+			got, stale, err := deserializeCompiledModuleWithUnmap(testVersion, io.NopCloser(bytes.NewReader(data[:end])), func(b []byte) error {
+				unmapped++
+				require.Equal(t, 4, len(b))
+				return platform.MunmapCodeSegment(b)
+			})
+			require.Nil(t, got)
+			require.True(t, err != nil || stale)
+			require.Equal(t, 1, unmapped)
+		})
+	}
+	t.Run("checksum mismatch", func(t *testing.T) {
+		corrupt := bytes.Clone(data)
+		corrupt[codeStart] ^= 0xff
+		unmapped := 0
+		_, _, err := deserializeCompiledModuleWithUnmap(testVersion, io.NopCloser(bytes.NewReader(corrupt)), func(b []byte) error {
+			unmapped++
+			return platform.MunmapCodeSegment(b)
+		})
+		require.Error(t, err)
+		require.Equal(t, 1, unmapped)
+	})
+	t.Run("successful load transfers ownership", func(t *testing.T) {
+		got, stale, err := deserializeCompiledModuleWithUnmap(testVersion, io.NopCloser(bytes.NewReader(data)), func([]byte) error {
+			t.Fatal("unexpected unmap")
+			return nil
+		})
+		require.NoError(t, err)
+		require.False(t, stale)
+		require.NoError(t, platform.MunmapCodeSegment(got.executable))
+	})
+}
+
+func TestDeserializeCompiledModuleEmptyExecutable(t *testing.T) {
+	cm := &compiledModule{executables: &executables{}}
+	got, stale, err := deserializeCompiledModule(testVersion, io.NopCloser(serializeCompiledModule(testVersion, cm)))
+	require.NoError(t, err)
+	require.False(t, stale)
+	require.Equal(t, 0, len(got.executable))
+}
+
+func TestReadWriteCacheStillDeletesStale(t *testing.T) {
+	dir := t.TempDir()
+	fc := filecache.New(dir)
+	module := &wasm.Module{}
+	data := concat(magic, []byte{byte(len(testVersion))}, []byte("9.9.9"), make([]byte, 4))
+	require.NoError(t, fc.Add(fileCacheKey(module), bytes.NewReader(data)))
+	e := &engine{fileCache: fc, wazeroVersion: testVersion}
+	_, hit, err := e.getCompiledModuleFromCache(module)
+	require.NoError(t, err)
+	require.False(t, hit)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(entries))
+}
+
+func TestReadOnlyCacheEntryDirectoryIsIO(t *testing.T) {
+	dir := t.TempDir()
+	module := &wasm.Module{FunctionSection: []wasm.Index{0}, CodeSection: []wasm.Code{{Body: []byte{0xff}}}}
+	require.NoError(t, filecache.New(dir).Add(fileCacheKey(module), bytes.NewReader(nil)))
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	entry := filepath.Join(dir, entries[0].Name())
+	require.NoError(t, os.Remove(entry))
+	require.NoError(t, os.Mkdir(entry, 0o700))
+	e := &engine{fileCache: filecache.NewReadOnly(dir), wazeroVersion: testVersion}
+	err = e.CompileModule(context.Background(), module, nil, false)
+	require.True(t, errors.Is(err, filecache.ErrIO), err)
+	require.False(t, errors.Is(err, filecache.ErrCorrupt))
+	info, err := os.Stat(entry)
+	require.NoError(t, err)
+	require.True(t, info.IsDir(), "failed entry must not be deleted")
+}
+
+type cacheReadFunc func([]byte) (int, error)
+
+func (f cacheReadFunc) Read(p []byte) (int, error) { return f(p) }
+
+func TestDeserializeCompiledModuleIOFailures(t *testing.T) {
+	data, err := io.ReadAll(serializeCompiledModule(testVersion, &compiledModule{
+		executables: &executables{executable: []byte{1, 2, 3, 4}}, functionOffsets: []int{0},
+	}))
+	require.NoError(t, err)
+	failure := errors.New("storage read failed")
+	codeStart := len(magic) + 1 + len(testVersion) + 4 + 8 + 8
+	for _, tc := range []struct {
+		name  string
+		end   int
+		unmap int
+	}{
+		{"header", 0, 0},
+		{"code after mmap", codeStart, 1},
+		{"try table after mmap", len(data) - 4, 1},
+		{"complete data with error", len(data), 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var reader io.Reader
+			if tc.end == len(data) {
+				input := bytes.NewReader(data)
+				reader = cacheReadFunc(func(p []byte) (int, error) {
+					n, err := input.Read(p)
+					if input.Len() == 0 {
+						return n, failure
+					}
+					return n, err
+				})
+			} else {
+				reader = io.MultiReader(bytes.NewReader(data[:tc.end]), cacheReadFunc(func([]byte) (int, error) {
+					return 0, failure
+				}))
+			}
+			unmapped := 0
+			cm, stale, err := deserializeCompiledModuleWithUnmap(testVersion, io.NopCloser(reader), func(b []byte) error {
+				unmapped++
+				return platform.MunmapCodeSegment(b)
+			})
+			require.Nil(t, cm)
+			require.False(t, stale, "storage failure must not trigger stale-entry deletion")
+			require.True(t, errors.Is(err, filecache.ErrIO), err)
+			require.True(t, errors.Is(err, failure), err)
+			require.Equal(t, tc.unmap, unmapped)
+		})
+	}
+}

--- a/internal/filecache/errors.go
+++ b/internal/filecache/errors.go
@@ -1,0 +1,13 @@
+package filecache
+
+import "errors"
+
+// These errors are exposed by wazero's public compilation cache API.
+var (
+	ErrMiss        = errors.New("compilation cache: required entry missing")
+	ErrStale       = errors.New("compilation cache: stale entry")
+	ErrCorrupt     = errors.New("compilation cache: corrupt entry")
+	ErrIO          = errors.New("compilation cache: I/O error")
+	ErrUnsupported = errors.New("compilation cache: engine does not support required persistent hits")
+	ErrReadOnly    = errors.New("compilation cache: read-only")
+)

--- a/internal/filecache/file_cache.go
+++ b/internal/filecache/file_cache.go
@@ -3,6 +3,7 @@ package filecache
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -18,11 +19,25 @@ func newFileCache(dir string) *fileCache {
 	return &fileCache{dirPath: dir}
 }
 
+// NewReadOnly requires cache hits and never modifies directory contents.
+func NewReadOnly(dir string) Cache {
+	return &fileCache{dirPath: dir, readOnly: true}
+}
+
+// ReadOnly reports whether c requires persistent cache hits.
+func ReadOnly(c Cache) bool {
+	r, ok := c.(interface{ ReadOnly() bool })
+	return ok && r.ReadOnly()
+}
+
+func (fc *fileCache) ReadOnly() bool { return fc.readOnly }
+
 // fileCache persists compiled functions into dirPath.
 //
 // Note: this can be expanded to do binary signing/verification, set TTL on each entry, etc.
 type fileCache struct {
-	dirPath string
+	dirPath  string
+	readOnly bool
 }
 
 func (fc *fileCache) path(key Key) string {
@@ -32,8 +47,14 @@ func (fc *fileCache) path(key Key) string {
 func (fc *fileCache) Get(key Key) (content io.ReadCloser, ok bool, err error) {
 	f, err := os.Open(fc.path(key))
 	if errors.Is(err, os.ErrNotExist) {
+		if fc.readOnly {
+			return nil, false, fmt.Errorf("%w: %s", ErrMiss, fc.path(key))
+		}
 		return nil, false, nil
 	} else if err != nil {
+		if fc.readOnly {
+			return nil, false, fmt.Errorf("%w: %w", ErrIO, err)
+		}
 		return nil, false, err
 	} else {
 		return f, true, nil
@@ -41,6 +62,9 @@ func (fc *fileCache) Get(key Key) (content io.ReadCloser, ok bool, err error) {
 }
 
 func (fc *fileCache) Add(key Key, content io.Reader) (err error) {
+	if fc.readOnly {
+		return ErrReadOnly
+	}
 	path := fc.path(key)
 	dirPath, fileName := filepath.Split(path)
 
@@ -68,6 +92,9 @@ func (fc *fileCache) Add(key Key, content io.Reader) (err error) {
 }
 
 func (fc *fileCache) Delete(key Key) (err error) {
+	if fc.readOnly {
+		return ErrReadOnly
+	}
 	err = os.Remove(fc.path(key))
 	if errors.Is(err, os.ErrNotExist) {
 		err = nil

--- a/internal/filecache/file_cache_readonly_test.go
+++ b/internal/filecache/file_cache_readonly_test.go
@@ -1,0 +1,45 @@
+package filecache
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	rw := newFileCache(dir)
+	ro := NewReadOnly(dir)
+	key := Key{1}
+	require.True(t, ReadOnly(ro))
+	require.False(t, ReadOnly(rw))
+	require.False(t, ReadOnly(nil))
+	_, hit, err := ro.Get(key)
+	require.False(t, hit)
+	require.True(t, errors.Is(err, ErrMiss))
+	require.NoError(t, rw.Add(key, bytes.NewReader([]byte("cached"))))
+	before, err := os.Stat(rw.path(key))
+	require.NoError(t, err)
+	require.True(t, errors.Is(ro.Add(key, bytes.NewReader(nil)), ErrReadOnly))
+	require.True(t, errors.Is(ro.Delete(key), ErrReadOnly))
+	r, hit, err := ro.Get(key)
+	require.NoError(t, err)
+	require.True(t, hit)
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	require.Equal(t, "cached", string(data))
+	after, err := os.Stat(rw.path(key))
+	require.NoError(t, err)
+	require.Equal(t, before.ModTime(), after.ModTime())
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(entries))
+	// An intermediate non-directory gives a deterministic I/O failure even as root.
+	_, _, err = NewReadOnly(rw.path(key)).Get(key)
+	require.True(t, errors.Is(err, ErrIO))
+}


### PR DESCRIPTION
## Summary

Add `NewCompilationCacheWithDirReadOnly` for applications that must use prepopulated compilation caches without compiling guest code on a miss.

- Existing cache directories are required; no mkdir, writes, stale-entry deletion or writable fallback.
- Missing, stale, corrupt, I/O and unsupported-engine outcomes are classifiable with `errors.Is`.
- Compiler guests must hit memory/disk cache; interpreter guests fail explicitly. Host modules remain supported.
- Failed native-cache decoding releases executable mappings, including failures after code/checksum/source-map loading.
- Existing writable hits, misses and stale-entry cleanup remain supported. Storage-read failures are distinguished from corrupt/stale data.
- Cache keys/formats, dependencies and version resolution stay unchanged.

This is **not zero code generation**: shared/host trampolines and bounded cache-hit entry preambles remain permitted. Cache bytes are trusted executable input, not an untrusted interchange format. Existing version, CPU-feature, artifact and compilation-configuration compatibility requirements still apply.

## Why read-only mounting is insufficient

The writable cache currently compiles a missing guest entry before attempting a write. A read-only filesystem therefore fails too late to avoid the compiler's memory peak. The new constructor makes that distinction explicit and fails before guest compilation.

Prior credential-free Linux/ARM64 measurements of an unmodified embedded SDK module motivate requiring hits:

| Condition | Median cgroup peak | Median core-ready time |
|---|---:|---:|
| No cache | 153.44 MiB | 4.408 s |
| Known warm cache hit | 61.27 MiB | 0.126 s |

Ten fresh processes per condition, interleaved with two warmups; Go 1.27.1, Extism 1.7.1, Wazero 1.11.0. A separate missing-entry/read-only-filesystem diagnostic still reached **164.52 MiB** before its write error (n=1). These are prior motivating measurements, **not performance measurements of this PR head**. This PR does not make existing hits faster; it prevents falling back to guest compilation when a hit is required.

Only aggregate, de-identified results are included. No personal, host, path, deployment or resource-configuration details. Cache pages were prewarmed and a small identical supervisor was included in cgroup accounting; this is not cold-node or authenticated-application memory acceptance. No optimized WASM or forced-GC measurements.

## Validation

- Targeted native race tests for the public API, file cache, wazevo and interpreter.
- `make test` on Go 1.25.0.
- `make check` on Go 1.25.0 with the repository-pinned linter (task-local installation); clean tree afterward.

Tests exercise fresh-engine cache-hit execution, missing/incompatible/corrupt entries with an intentionally unusable guest compiler, unchanged cache bytes/mtime/mode, interpreter guest rejection/host allowance, executable unmapping at every truncated metadata boundary, header/post-mapping storage failures (including data returned together with an error), and writable miss/stale behavior.

No fork/version-identity changes, CLI, build/image pipeline, benchmark bundle or downstream deployment changes are included.
