### PR TITLE
api: add ExportedTable to api.Module and CompiledModule.ExportedTables

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -293,6 +293,31 @@ type MemoryDefinition interface {
 	internalapi.WazeroOnly
 }
 
+// TableDefinition is a WebAssembly table exported in a module
+// (wazero.CompiledModule).
+//
+// See https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/syntax/modules.html#tables
+//
+// # Notes
+//
+//   - This is an interface for decoupling, not third-party implementations.
+//     All implementations are in wazero.
+type TableDefinition interface {
+	ExportDefinition
+
+	// Type returns the reference type of this table's elements: RefTypeFuncref or RefTypeExternref.
+	Type() ValueType
+
+	// Min returns the initial count of elements in this table.
+	Min() uint32
+
+	// Max returns the max count of elements in this table, or false if
+	// unbounded.
+	Max() (uint32, bool)
+
+	internalapi.WazeroOnly
+}
+
 // FunctionDefinition is a WebAssembly function exported in a module
 // (wazero.CompiledModule).
 //

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -164,7 +164,11 @@ type Module interface {
 	// definitions in this module, keyed on export name.
 	ExportedFunctionDefinitions() map[string]FunctionDefinition
 
-	// TODO: Table
+	// ExportedTable returns a table exported from this module or nil if it wasn't.
+	//
+	// wazero#2461 tracks this gap upstream; this fork adds it ahead of that issue being resolved there - see
+	// this fork's README for the divergence/maintenance note.
+	ExportedTable(name string) Table
 
 	// ExportedMemory returns a memory exported from this module or nil if it wasn't.
 	//
@@ -546,6 +550,58 @@ type MutableGlobal interface {
 	//
 	// See Global.Type for how to encode this value from a Go type.
 	Set(v uint64)
+
+	internalapi.WazeroOnly
+}
+
+// Table is a WebAssembly table exported from an instantiated module (wazero.Runtime InstantiateModule).
+//
+// wazero's internal representation of a table element (a funcref or externref) is a raw uintptr - the same
+// Reference type used to build ElementSegment/TableInstance internally. Get, Set and Grow encode/decode that
+// value as a uint64 on the way in/out, the same convention Global.Get/MutableGlobal.Set already use, and the
+// same one EncodeExternref/DecodeExternref exist for: an externref-typed table stores whatever uintptr the host
+// chose to put there (frequently a handle/index into a host-side registry rather than a real Go pointer, since a
+// raw uintptr is invisible to the Go garbage collector - see EncodeExternref's own doc).
+//
+// This diverges from the shape proposed in wazero#2461 (`Set(ctx, i, myHostObj any)`, taking a live Go value
+// directly): that shape would require wazero itself to keep host objects alive opposite the GC, which wazero does
+// not do for globals or memory either. Get/Set here stay symmetric with the rest of this package instead.
+//
+// See https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/syntax/modules.html#tables
+//
+// # Notes
+//
+//   - This is an interface for decoupling, not third-party implementations.
+//     All implementations are in wazero.
+type Table interface {
+	fmt.Stringer
+
+	// Type returns the reference type of this table's elements: RefTypeFuncref or RefTypeExternref.
+	Type() ValueType
+
+	// Size returns the count of elements in the table.
+	//
+	// See https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-size-x
+	Size() uint32
+
+	// Grow increases the table by delta elements, initializing any new elements to init (encoded the same way
+	// Set encodes v). Returns the previous size, or false if the growth was rejected (e.g. delta would exceed the
+	// table's declared maximum) - the same "returns false instead of -1" convention as Memory.Grow.
+	//
+	// See https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-grow-x
+	Grow(delta uint32, init uint64) (previousSize uint32, ok bool)
+
+	// Get returns the raw reference at index i (decode with DecodeExternref for an externref table), or an error
+	// if i is out of bounds.
+	//
+	// See https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-get-x
+	Get(i uint32) (ref uint64, err error)
+
+	// Set writes v (encode with EncodeExternref for an externref table) at index i, or returns an error if i is
+	// out of bounds.
+	//
+	// See https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-set-x
+	Set(i uint32, v uint64) error
 
 	internalapi.WazeroOnly
 }

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -165,9 +165,6 @@ type Module interface {
 	ExportedFunctionDefinitions() map[string]FunctionDefinition
 
 	// ExportedTable returns a table exported from this module or nil if it wasn't.
-	//
-	// wazero#2461 tracks this gap upstream; this fork adds it ahead of that issue being resolved there - see
-	// this fork's README for the divergence/maintenance note.
 	ExportedTable(name string) Table
 
 	// ExportedMemory returns a memory exported from this module or nil if it wasn't.
@@ -581,16 +578,15 @@ type MutableGlobal interface {
 
 // Table is a WebAssembly table exported from an instantiated module (wazero.Runtime InstantiateModule).
 //
-// wazero's internal representation of a table element (a funcref or externref) is a raw uintptr - the same
-// Reference type used to build ElementSegment/TableInstance internally. Get, Set and Grow encode/decode that
-// value as a uint64 on the way in/out, the same convention Global.Get/MutableGlobal.Set already use, and the
-// same one EncodeExternref/DecodeExternref exist for: an externref-typed table stores whatever uintptr the host
-// chose to put there (frequently a handle/index into a host-side registry rather than a real Go pointer, since a
-// raw uintptr is invisible to the Go garbage collector - see EncodeExternref's own doc).
+// A table element (a funcref or externref) is represented internally as a raw uintptr, the same Reference
+// type ElementSegment/TableInstance already use. Get, Set and Grow encode and decode that value as a uint64,
+// the same convention Global.Get/MutableGlobal.Set use, via EncodeExternref/DecodeExternref. An externref
+// table stores whatever uintptr the host puts there, often a handle into a host-side registry rather than a
+// real Go pointer, since a raw uintptr isn't visible to the Go garbage collector - see EncodeExternref's doc.
 //
-// This diverges from the shape proposed in wazero#2461 (`Set(ctx, i, myHostObj any)`, taking a live Go value
-// directly): that shape would require wazero itself to keep host objects alive opposite the GC, which wazero does
-// not do for globals or memory either. Get/Set here stay symmetric with the rest of this package instead.
+// Get/Set don't hand back a live Go value directly, the way a table's own host object might suggest: wazero
+// doesn't keep host objects alive against the GC for Global or Memory either, and a table shouldn't be an
+// exception.
 //
 // See https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/syntax/modules.html#tables
 //

--- a/config.go
+++ b/config.go
@@ -346,6 +346,17 @@ type CompiledModule interface {
 	// memory.
 	ExportedMemories() map[string]api.MemoryDefinition
 
+	// ImportedTables returns all the imported tables
+	// (api.TableDefinition) in this module or nil if there are none.
+	//
+	// Note: Unlike ExportedTables, there is no unique constraint on
+	// imports.
+	ImportedTables() []api.TableDefinition
+
+	// ExportedTables returns all the exported tables
+	// (api.TableDefinition) in this module keyed on export name.
+	ExportedTables() map[string]api.TableDefinition
+
 	// CustomSections returns all the custom sections
 	// (api.CustomSection) in this module keyed on the section name.
 	CustomSections() []api.CustomSection
@@ -402,6 +413,16 @@ func (c *compiledModule) ImportedMemories() []api.MemoryDefinition {
 // ExportedMemories implements CompiledModule.ExportedMemories
 func (c *compiledModule) ExportedMemories() map[string]api.MemoryDefinition {
 	return c.module.ExportedMemories()
+}
+
+// ImportedTables implements CompiledModule.ImportedTables
+func (c *compiledModule) ImportedTables() []api.TableDefinition {
+	return c.module.ImportedTables()
+}
+
+// ExportedTables implements CompiledModule.ExportedTables
+func (c *compiledModule) ExportedTables() map[string]api.TableDefinition {
+	return c.module.ExportedTables()
 }
 
 // CustomSections implements CompiledModule.CustomSections

--- a/experimental/wazerotest/wazerotest.go
+++ b/experimental/wazerotest/wazerotest.go
@@ -105,6 +105,12 @@ func (m *Module) ExportedGlobal(name string) api.Global {
 	return m.exportedGlobals[name]
 }
 
+// ExportedTable implements the same method as documented on api.Module. This
+// test helper doesn't model tables - always returns nil.
+func (m *Module) ExportedTable(name string) api.Table {
+	return nil
+}
+
 // Close implements the same method as documented on api.Closer.
 func (m *Module) Close(ctx context.Context) error {
 	return m.CloseWithExitCode(ctx, 0)

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -192,6 +192,12 @@ type Module struct {
 	// MemoryDefinitionSection is a wazero-specific section.
 	MemoryDefinitionSection []MemoryDefinition
 
+	// TableDefinitionSection is a wazero-specific section, mirroring
+	// MemoryDefinitionSection - added alongside ExportedTable (wazero#2461)
+	// so exported tables can be enumerated the same way exported memories
+	// already are.
+	TableDefinitionSection []TableDefinition
+
 	// DWARFLines is used to emit DWARF based stack trace. This is created from the multiple custom sections
 	// as described in https://yurydelendik.github.io/webassembly-dwarf/, though it is not specified in the Wasm
 	// specification: https://github.com/WebAssembly/debugging/issues/1

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -193,9 +193,8 @@ type Module struct {
 	MemoryDefinitionSection []MemoryDefinition
 
 	// TableDefinitionSection is a wazero-specific section, mirroring
-	// MemoryDefinitionSection - added alongside ExportedTable (wazero#2461)
-	// so exported tables can be enumerated the same way exported memories
-	// already are.
+	// MemoryDefinitionSection so exported tables can be enumerated the
+	// same way exported memories already are.
 	TableDefinitionSection []TableDefinition
 
 	// DWARFLines is used to emit DWARF based stack trace. This is created from the multiple custom sections

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -227,6 +227,15 @@ func (m *ModuleInstance) GlobalVal(idx Index) uint64 {
 	return m.Globals[idx].Val
 }
 
+// ExportedTable implements the same method as documented on api.Module.
+func (m *ModuleInstance) ExportedTable(name string) api.Table {
+	exp, err := m.getExport(name, ExternTypeTable)
+	if err != nil {
+		return nil
+	}
+	return exportedTable{t: m.Tables[exp.Index]}
+}
+
 // ExportedGlobal implements the same method as documented on api.Module.
 func (m *ModuleInstance) ExportedGlobal(name string) api.Global {
 	exp, err := m.getExport(name, ExternTypeGlobal)

--- a/internal/wasm/table.go
+++ b/internal/wasm/table.go
@@ -276,6 +276,27 @@ func (m *ModuleInstance) buildTables(module *Module, skipBoundCheck bool) (err e
 	return
 }
 
+// Get returns the raw reference at index i, or an error if i is out of bounds.
+//
+// See api.Table.Get
+func (t *TableInstance) Get(i uint32) (Reference, error) {
+	if i >= uint32(len(t.References)) {
+		return 0, fmt.Errorf("out of bounds table access %d >= %d", i, len(t.References))
+	}
+	return t.References[i], nil
+}
+
+// Set writes ref at index i, or returns an error if i is out of bounds.
+//
+// See api.Table.Set
+func (t *TableInstance) Set(i uint32, ref Reference) error {
+	if i >= uint32(len(t.References)) {
+		return fmt.Errorf("out of bounds table access %d >= %d", i, len(t.References))
+	}
+	t.References[i] = ref
+	return nil
+}
+
 // checkSegmentBounds fails if the capacity needed for an ElementSegment.Init is larger than limitsType.Min
 //
 // WebAssembly 1.0 (20191205) doesn't forbid growing to accommodate element segments, and spectests are inconsistent.

--- a/internal/wasm/table_api.go
+++ b/internal/wasm/table_api.go
@@ -1,0 +1,55 @@
+package wasm
+
+import (
+	"fmt"
+
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/internalapi"
+)
+
+// exportedTable wraps TableInstance to implement api.Table.
+type exportedTable struct {
+	internalapi.WazeroOnlyType
+	t *TableInstance
+}
+
+// Type implements api.Table.
+func (t exportedTable) Type() api.ValueType {
+	return t.t.Type.Kind()
+}
+
+// Size implements api.Table.
+func (t exportedTable) Size() uint32 {
+	return uint32(len(t.t.References))
+}
+
+// Grow implements api.Table.
+func (t exportedTable) Grow(delta uint32, init uint64) (previousSize uint32, ok bool) {
+	previousSize = t.t.Grow(delta, Reference(init))
+	// TableInstance.Grow's own sentinel for "rejected" is the same -1-as-uint32 value the table.grow
+	// instruction itself returns, per its doc comment. delta==0 always returns the (possibly identical
+	// looking) current length rather than failing, so only treat the sentinel as failure when a real
+	// grow was requested.
+	if delta != 0 && previousSize == 0xffffffff {
+		return 0, false
+	}
+	return previousSize, true
+}
+
+// Get implements api.Table.
+func (t exportedTable) Get(i uint32) (uint64, error) {
+	ref, err := t.t.Get(i)
+	return uint64(ref), err
+}
+
+// Set implements api.Table.
+func (t exportedTable) Set(i uint32, v uint64) error {
+	return t.t.Set(i, Reference(v))
+}
+
+// String implements fmt.Stringer.
+func (t exportedTable) String() string {
+	return fmt.Sprintf("Table(%s)", RefTypeName(t.t.Type))
+}
+
+var _ api.Table = exportedTable{}

--- a/internal/wasm/table_definition.go
+++ b/internal/wasm/table_definition.go
@@ -1,0 +1,133 @@
+package wasm
+
+import (
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/internalapi"
+)
+
+// ImportedTables implements the same method as documented on wazero.CompiledModule.
+func (m *Module) ImportedTables() (ret []api.TableDefinition) {
+	for i := range m.TableDefinitionSection {
+		d := &m.TableDefinitionSection[i]
+		if d.importDesc != nil {
+			ret = append(ret, d)
+		}
+	}
+	return
+}
+
+// ExportedTables implements the same method as documented on wazero.CompiledModule.
+func (m *Module) ExportedTables() map[string]api.TableDefinition {
+	ret := map[string]api.TableDefinition{}
+	for i := range m.TableDefinitionSection {
+		d := &m.TableDefinitionSection[i]
+		for _, e := range d.exportNames {
+			ret[e] = d
+		}
+	}
+	return ret
+}
+
+// BuildTableDefinitions generates table metadata that can be parsed from
+// the module, mirroring BuildMemoryDefinitions. This must be called after
+// all validation.
+//
+// Note: This is exported for wazero.Runtime CompileModule.
+func (m *Module) BuildTableDefinitions() {
+	var moduleName string
+	if m.NameSection != nil {
+		moduleName = m.NameSection.ModuleName
+	}
+
+	tableCount := m.ImportTableCount + uint32(len(m.TableSection))
+	if tableCount == 0 {
+		return
+	}
+
+	m.TableDefinitionSection = make([]TableDefinition, 0, tableCount)
+	importTableIdx := Index(0)
+	for i := range m.ImportSection {
+		imp := &m.ImportSection[i]
+		if imp.Type != ExternTypeTable {
+			continue
+		}
+
+		desc := imp.DescTable
+		m.TableDefinitionSection = append(m.TableDefinitionSection, TableDefinition{
+			importDesc: &[2]string{imp.Module, imp.Name},
+			index:      importTableIdx,
+			table:      &desc,
+		})
+		importTableIdx++
+	}
+
+	for i := range m.TableSection {
+		m.TableDefinitionSection = append(m.TableDefinitionSection, TableDefinition{
+			index: importTableIdx,
+			table: &m.TableSection[i],
+		})
+		importTableIdx++
+	}
+
+	for i := range m.TableDefinitionSection {
+		d := &m.TableDefinitionSection[i]
+		d.moduleName = moduleName
+		for i := range m.ExportSection {
+			e := &m.ExportSection[i]
+			if e.Type == ExternTypeTable && e.Index == d.index {
+				d.exportNames = append(d.exportNames, e.Name)
+			}
+		}
+	}
+}
+
+// TableDefinition implements api.TableDefinition
+type TableDefinition struct {
+	internalapi.WazeroOnlyType
+	moduleName  string
+	index       Index
+	importDesc  *[2]string
+	exportNames []string
+	table       *Table
+}
+
+// ModuleName implements the same method as documented on api.TableDefinition.
+func (d *TableDefinition) ModuleName() string {
+	return d.moduleName
+}
+
+// Index implements the same method as documented on api.TableDefinition.
+func (d *TableDefinition) Index() uint32 {
+	return d.index
+}
+
+// Import implements the same method as documented on api.TableDefinition.
+func (d *TableDefinition) Import() (moduleName, name string, isImport bool) {
+	if importDesc := d.importDesc; importDesc != nil {
+		moduleName, name, isImport = importDesc[0], importDesc[1], true
+	}
+	return
+}
+
+// ExportNames implements the same method as documented on api.TableDefinition.
+func (d *TableDefinition) ExportNames() []string {
+	return d.exportNames
+}
+
+// Type implements the same method as documented on api.TableDefinition.
+func (d *TableDefinition) Type() api.ValueType {
+	return d.table.Type.Kind()
+}
+
+// Min implements the same method as documented on api.TableDefinition.
+func (d *TableDefinition) Min() uint32 {
+	return d.table.Min
+}
+
+// Max implements the same method as documented on api.TableDefinition.
+func (d *TableDefinition) Max() (max uint32, ok bool) {
+	if d.table.Max == nil {
+		return 0, false
+	}
+	return *d.table.Max, true
+}

--- a/internal/wasm/table_definition_test.go
+++ b/internal/wasm/table_definition_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-// TestModule_BuildTableDefinitions mirrors TestModule_BuildMemoryDefinitions -
-// added alongside ExportedTable (wazero#2461) so CompiledModule.ExportedTables
-// gets the same coverage ExportedMemories already has.
+// TestModule_BuildTableDefinitions mirrors TestModule_BuildMemoryDefinitions
+// so CompiledModule.ExportedTables gets the same coverage ExportedMemories
+// already has.
 func TestModule_BuildTableDefinitions(t *testing.T) {
 	max := uint32(3)
 

--- a/internal/wasm/table_definition_test.go
+++ b/internal/wasm/table_definition_test.go
@@ -1,0 +1,126 @@
+package wasm
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+// TestModule_BuildTableDefinitions mirrors TestModule_BuildMemoryDefinitions -
+// added alongside ExportedTable (wazero#2461) so CompiledModule.ExportedTables
+// gets the same coverage ExportedMemories already has.
+func TestModule_BuildTableDefinitions(t *testing.T) {
+	max := uint32(3)
+
+	tests := []struct {
+		name            string
+		m               *Module
+		expected        []TableDefinition
+		expectedImports []api.TableDefinition
+		expectedExports map[string]api.TableDefinition
+	}{
+		{
+			name:            "no exports",
+			m:               &Module{},
+			expectedExports: map[string]api.TableDefinition{},
+		},
+		{
+			name: "no tables",
+			m: &Module{
+				ExportSection: []Export{{Type: ExternTypeGlobal, Index: 0}},
+				GlobalSection: []Global{{}},
+			},
+			expectedExports: map[string]api.TableDefinition{},
+		},
+		{
+			name:            "defines table{2,}",
+			m:               &Module{TableSection: []Table{{Min: 2, Type: RefTypeFuncref}}},
+			expected:        []TableDefinition{{index: 0, table: &Table{Min: 2, Type: RefTypeFuncref}}},
+			expectedExports: map[string]api.TableDefinition{},
+		},
+		{
+			name: "exports defined table{2,3}",
+			m: &Module{
+				ExportSection: []Export{
+					{Name: "table_index=0", Type: ExternTypeTable, Index: 0},
+					{Name: "", Type: ExternTypeGlobal, Index: 0},
+				},
+				GlobalSection: []Global{{}},
+				TableSection:  []Table{{Min: 2, Max: &max, Type: RefTypeExternref}},
+			},
+			expected: []TableDefinition{
+				{
+					index:       0,
+					exportNames: []string{"table_index=0"},
+					table:       &Table{Min: 2, Max: &max, Type: RefTypeExternref},
+				},
+			},
+			expectedExports: map[string]api.TableDefinition{
+				"table_index=0": &TableDefinition{
+					index:       0,
+					exportNames: []string{"table_index=0"},
+					table:       &Table{Min: 2, Max: &max, Type: RefTypeExternref},
+				},
+			},
+		},
+		{
+			name: "exports imported table{0,} and defined table{2,3}",
+			m: &Module{
+				ImportSection: []Import{{
+					Type:      ExternTypeTable,
+					DescTable: Table{Min: 0, Type: RefTypeFuncref},
+				}},
+				ExportSection: []Export{
+					{Name: "imported_table", Type: ExternTypeTable, Index: 0},
+					{Name: "table_index=1", Type: ExternTypeTable, Index: 1},
+				},
+				TableSection: []Table{{Min: 2, Max: &max, Type: RefTypeExternref}},
+			},
+			expected: []TableDefinition{
+				{
+					index:       0,
+					importDesc:  &[2]string{"", ""},
+					exportNames: []string{"imported_table"},
+					table:       &Table{Min: 0, Type: RefTypeFuncref},
+				},
+				{
+					index:       1,
+					exportNames: []string{"table_index=1"},
+					table:       &Table{Min: 2, Max: &max, Type: RefTypeExternref},
+				},
+			},
+			expectedImports: []api.TableDefinition{
+				&TableDefinition{
+					index:       0,
+					importDesc:  &[2]string{"", ""},
+					exportNames: []string{"imported_table"},
+					table:       &Table{Min: 0, Type: RefTypeFuncref},
+				},
+			},
+			expectedExports: map[string]api.TableDefinition{
+				"imported_table": &TableDefinition{
+					index:       0,
+					importDesc:  &[2]string{"", ""},
+					exportNames: []string{"imported_table"},
+					table:       &Table{Min: 0, Type: RefTypeFuncref},
+				},
+				"table_index=1": &TableDefinition{
+					index:       1,
+					exportNames: []string{"table_index=1"},
+					table:       &Table{Min: 2, Max: &max, Type: RefTypeExternref},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tc.m.BuildTableDefinitions()
+			require.Equal(t, tc.expected, tc.m.TableDefinitionSection)
+			require.Equal(t, tc.expectedImports, tc.m.ImportedTables())
+			require.Equal(t, tc.expectedExports, tc.m.ExportedTables())
+		})
+	}
+}

--- a/runtime.go
+++ b/runtime.go
@@ -245,9 +245,9 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 	// TODO: lazy initialization of memory definition.
 	internal.BuildMemoryDefinitions()
 
-	// Same for tables, mirroring BuildMemoryDefinitions - added alongside
-	// ExportedTable (wazero#2461) so CompiledModule.ExportedTables can
-	// enumerate table exports the same way ExportedMemories already does.
+	// Same for tables, mirroring BuildMemoryDefinitions so
+	// CompiledModule.ExportedTables can enumerate table exports the same
+	// way ExportedMemories already does.
 	internal.BuildTableDefinitions()
 
 	c := &compiledModule{module: internal, compiledEngine: r.store.Engine}

--- a/runtime.go
+++ b/runtime.go
@@ -245,6 +245,11 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 	// TODO: lazy initialization of memory definition.
 	internal.BuildMemoryDefinitions()
 
+	// Same for tables, mirroring BuildMemoryDefinitions - added alongside
+	// ExportedTable (wazero#2461) so CompiledModule.ExportedTables can
+	// enumerate table exports the same way ExportedMemories already does.
+	internal.BuildTableDefinitions()
+
 	c := &compiledModule{module: internal, compiledEngine: r.store.Engine}
 
 	// typeIDs are static and compile-time known.

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -326,8 +326,7 @@ func TestModule_Global(t *testing.T) {
 	}
 }
 
-// TestModule_Table covers api.Module.ExportedTable - added alongside this
-// fork's ExportedTable/api.Table gap fix (wazero#2461), mirroring
+// TestModule_Table covers api.Module.ExportedTable, mirroring
 // TestModule_Global's own no-export/exported table cases directly above.
 func TestModule_Table(t *testing.T) {
 	max := uint32(5)

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -326,6 +326,96 @@ func TestModule_Global(t *testing.T) {
 	}
 }
 
+// TestModule_Table covers api.Module.ExportedTable - added alongside this
+// fork's ExportedTable/api.Table gap fix (wazero#2461), mirroring
+// TestModule_Global's own no-export/exported table cases directly above.
+func TestModule_Table(t *testing.T) {
+	max := uint32(5)
+
+	tests := []struct {
+		name     string
+		module   *wasm.Module
+		expected bool
+	}{
+		{
+			name:   "no table",
+			module: &wasm.Module{},
+		},
+		{
+			name: "table not exported",
+			module: &wasm.Module{
+				TableSection: []wasm.Table{{Min: 2, Max: &max, Type: wasm.RefTypeExternref}},
+			},
+		},
+		{
+			name: "table exported",
+			module: &wasm.Module{
+				TableSection: []wasm.Table{{Min: 2, Max: &max, Type: wasm.RefTypeExternref}},
+				Exports: map[string]*wasm.Export{
+					"table": {Type: wasm.ExternTypeTable, Name: "table"},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRuntime(testCtx).(*runtime)
+			defer r.Close(testCtx)
+
+			code := &compiledModule{module: tc.module}
+
+			err := r.store.Engine.CompileModule(testCtx, code.module, nil, false)
+			require.NoError(t, err)
+
+			module, err := r.InstantiateModule(testCtx, code, NewModuleConfig())
+			require.NoError(t, err)
+
+			table := module.ExportedTable("table")
+			if !tc.expected {
+				require.Nil(t, table)
+				return
+			}
+			require.Equal(t, api.ValueTypeExternref, table.Type())
+			require.Equal(t, uint32(2), table.Size())
+
+			// Fresh externref slots start out null (Reference zero).
+			ref, err := table.Get(0)
+			require.NoError(t, err)
+			require.Equal(t, uint64(0), ref)
+
+			// Set/Get round-trips a raw reference.
+			require.NoError(t, table.Set(1, api.EncodeExternref(0xdeadbeef)))
+			ref, err = table.Get(1)
+			require.NoError(t, err)
+			require.Equal(t, uintptr(0xdeadbeef), api.DecodeExternref(ref))
+
+			// Out of bounds access errors rather than panicking.
+			_, err = table.Get(2)
+			require.Error(t, err)
+			require.Error(t, table.Set(2, 0))
+
+			// Grow appends delta elements initialized to init, and returns the
+			// previous size.
+			prev, ok := table.Grow(3, api.EncodeExternref(7))
+			require.True(t, ok)
+			require.Equal(t, uint32(2), prev)
+			require.Equal(t, uint32(5), table.Size())
+			ref, err = table.Get(4)
+			require.NoError(t, err)
+			require.Equal(t, uintptr(7), api.DecodeExternref(ref))
+
+			// Growing past Max is rejected, not silently clamped.
+			_, ok = table.Grow(1, 0)
+			require.False(t, ok)
+			require.Equal(t, uint32(5), table.Size())
+		})
+	}
+}
+
 func TestRuntime_InstantiateModule_UsesContext(t *testing.T) {
 	r := NewRuntime(testCtx)
 	defer r.Close(testCtx)


### PR DESCRIPTION
Closes #2461.

`api.Module` has `ExportedFunction`/`ExportedMemory`/`ExportedGlobal` but a
literal `// TODO: Table` where `ExportedTable` would go. This fills that gap,
mirroring the existing accessors' shape.

## Changes

- `api.Table`: `Type()`/`Size()`/`Grow(delta, init uint64) (prev uint32, ok
  bool)`/`Get(i uint32) (uint64, error)`/`Set(i uint32, v uint64) error`.
  References are encoded and decoded as `uint64`, the same convention
  `Global.Get`/`MutableGlobal.Set` already use, via the existing
  `EncodeExternref`/`DecodeExternref` helpers.
- `api.Module.ExportedTable(name string) api.Table`, resolving an export the
  same way `ExportedMemory`/`ExportedGlobal` do.
- `CompiledModule.ExportedTables()`/`ImportedTables()` returning
  `api.TableDefinition` (`Type`/`Min`/`Max` plus `ExportDefinition`),
  mirroring `ExportedMemories`/`ImportedMemories`/`MemoryDefinition` line for
  line. A host needs this to enumerate which table names to call
  `ExportedTable` on, the same way it already walks
  `ExportedMemories()`/`ExportedFunctions()`.
- `TableInstance` (internal) gains `Get`/`Set`. Only `Grow` existed before.

## Design note

The issue proposes `Set(ctx, i, obj any)`, taking a live Go value directly. I
went with the `uint64`-encoded shape above instead. `Global` and `Memory`
don't hand back live Go values either, and neither keeps a host object alive
against the GC for any other exported accessor. An externref table storing a
raw `uintptr` can't safely do that for an arbitrary Go value reachable only
through it. A host that wants to store real objects in an externref table,
the way wasm-bindgen's own generated glue does, needs its own handle
registry on top of this regardless. Open to a different shape if a
maintainer prefers one.

## Testing

- `go test ./...`: green,
- New table-driven tests mirroring the existing `Global`/`Memory` coverage:
  `TestModule_Table` (runtime_test.go) and `TestModule_BuildTableDefinitions`
  (mirroring `TestModule_BuildMemoryDefinitions`).
- Verified against an external wasm-bindgen-generated module: a Rust/wasm-bindgen package exporting an externref
  table for its object heap. Drove it through `ExportedTable` end to end
  (`.Grow`/`.Get`/`.Set`) and got output byte-for-byte identical to the same
  module run under Node's native `WebAssembly.Table`.

## Disclosure

I've used Claude to implement this. I needed table exports for another project and figured it was worth contributing back upstream.
